### PR TITLE
Type library support: spec operators, configSchema defaults, local schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,21 @@ TEMPLATE
 <<Replace this placeholder with a list using this user prompt: ([{<List 4 examples of sustainable technology>}]). Format requirements: Use bullet_points formatting with each item on a new line. Create exactly 4 items.>>
 ```
 
+## Published type libraries
+
+Templates import instruction types through `extends`. The specification publishes these libraries under `https://alexanderparker.github.io/instruction-template-specification/schema/v1.0/`, all trusted by the compiler's built-in allowlist patterns:
+
+| Library        | File                         | Purpose                                                                       |
+| -------------- | ---------------------------- | ----------------------------------------------------------------------------- |
+| Standard Types | `its-standard-types-v1.json` | Prose content: titles, lists, paragraphs, tables, dialogue and more           |
+| JSON Types     | `its-json-types-v1.json`     | Raw JSON output: values, objects, arrays, JSON Schema documents               |
+| HTML Types     | `its-html-types-v1.json`     | Raw HTML fragments: containers, tables, lists, form fields (never full pages) |
+| YAML Types     | `its-yaml-types-v1.json`     | Raw YAML output: blocks, complete documents, markdown frontmatter             |
+
+The structured-output libraries (JSON, HTML, YAML) instruct the model to emit raw output with no markdown code fences and no commentary. If a placeholder omits a config property, defaults declared in the library's `configSchema` are substituted into the compiled instruction.
+
+`extends` entries may also be local file paths relative to the template, useful when developing unpublished type libraries. This is disabled by default; enable it with `SecurityConfig.allow_local_schemas()` or `ITS_ALLOW_LOCAL_SCHEMAS=true`.
+
 ## Python Library Usage
 
 ### Basic Usage
@@ -227,7 +242,7 @@ compiler = ITSCompiler(config=config, security_config=security_config)
 **Conditional operators:**
 
 - Comparison: `==`, `!=`, `<`, `<=`, `>`, `>=`
-- Boolean: `and`, `or`, `not`
+- Boolean: `&&`, `||`, `!` (the specification's operators), with `and`, `or`, `not` accepted as equivalents
 - Membership: `in`, `not in`
 
 ## Configuration
@@ -237,6 +252,7 @@ compiler = ITSCompiler(config=config, security_config=security_config)
 **Network Security:**
 
 - `ITS_ALLOW_HTTP` - Allow HTTP URLs (default: false)
+- `ITS_ALLOW_LOCAL_SCHEMAS` - Allow extends to resolve local file paths relative to the template (default: false)
 - `ITS_BLOCK_LOCALHOST` - Block localhost access (default: true)
 - `ITS_REQUEST_TIMEOUT` - Network timeout in seconds (default: 10)
 - `ITS_DOMAIN_ALLOWLIST` - Comma-separated allowed domains

--- a/its_compiler/core/conditional_evaluator.py
+++ b/its_compiler/core/conditional_evaluator.py
@@ -8,6 +8,7 @@ from typing import Any, Callable, Dict, List, Optional
 
 from ..security import ExpressionSanitiser, SecurityConfig
 from .exceptions import ITSConditionalError
+from .expression_utils import translate_condition_operators
 
 
 class ConditionalEvaluator:
@@ -78,7 +79,7 @@ class ConditionalEvaluator:
                     condition=condition,
                 )
         else:
-            sanitised_condition = condition
+            sanitised_condition = translate_condition_operators(condition)
 
         try:
             # Convert single quotes to double quotes for proper Python parsing

--- a/its_compiler/core/expression_utils.py
+++ b/its_compiler/core/expression_utils.py
@@ -1,0 +1,52 @@
+"""Utilities for conditional expression handling."""
+
+
+def translate_condition_operators(expression: str) -> str:
+    """Translate the specification's condition operators to Python equivalents.
+
+    The ITS specification documents JavaScript-style operators (&&, || and
+    unary !) in conditional expressions. Python's ast cannot parse them, so
+    they are rewritten to and/or/not before parsing. Content inside string
+    literals is left untouched, and != is preserved. The translation is
+    idempotent: expressions already using Python operators pass through
+    unchanged.
+    """
+    result = []
+    i = 0
+    quote = None
+
+    while i < len(expression):
+        ch = expression[i]
+
+        if quote is not None:
+            result.append(ch)
+            if ch == quote:
+                quote = None
+            i += 1
+            continue
+
+        if ch in ("'", '"'):
+            quote = ch
+            result.append(ch)
+            i += 1
+            continue
+
+        if expression.startswith("&&", i):
+            result.append(" and ")
+            i += 2
+            continue
+
+        if expression.startswith("||", i):
+            result.append(" or ")
+            i += 2
+            continue
+
+        if ch == "!" and not expression.startswith("!=", i):
+            result.append(" not ")
+            i += 1
+            continue
+
+        result.append(ch)
+        i += 1
+
+    return "".join(result).strip()

--- a/its_compiler/core/models.py
+++ b/its_compiler/core/models.py
@@ -222,11 +222,23 @@ class InstructionTypeDefinition:
         # pattern ([{<{description}>}]), so we just substitute the description directly
         formatted_template = formatted_template.replace("{description}", description)
 
-        # Replace other config template_variables
+        # Merge configSchema defaults beneath the supplied config so template
+        # strings render from defaults when a property is omitted
+        substitutions: Dict[str, Any] = {}
+        schema_properties = (self.config_schema or {}).get("properties", {})
+        if isinstance(schema_properties, dict):
+            for key, prop_schema in schema_properties.items():
+                if isinstance(prop_schema, dict) and "default" in prop_schema:
+                    substitutions[key] = prop_schema["default"]
         for key, value in config.items():
             if key != "description":
-                template_variable = "{" + key + "}"
-                formatted_template = formatted_template.replace(template_variable, str(value))
+                substitutions[key] = value
+
+        for key, value in substitutions.items():
+            template_variable = "{" + key + "}"
+            # Booleans render JSON-style for cross-compiler consistency
+            rendered = str(value).lower() if isinstance(value, bool) else str(value)
+            formatted_template = formatted_template.replace(template_variable, rendered)
 
         # Check for any remaining unreplaced template_variables, but exclude patterns that are
         # part of the user content wrapper (like {<content>} or {<description with spaces>})

--- a/its_compiler/core/schema_loader.py
+++ b/its_compiler/core/schema_loader.py
@@ -53,8 +53,11 @@ class SchemaLoader:
         # Security validation
         self._validate_schema_security(schema_url)
 
-        # Check allowlist
-        if self.allowlist_manager and not self.allowlist_manager.is_allowed(schema_url):
+        # Check allowlist. Local file schemas are exempt: they only reach this
+        # point when file access is explicitly enabled, and the allowlist
+        # exists to gate remote schema origins.
+        is_local_file = schema_url.startswith("file:")
+        if not is_local_file and self.allowlist_manager and not self.allowlist_manager.is_allowed(schema_url):
             raise ITSSchemaError(
                 f"Schema not in allowlist and user denied access: {schema_url}",
                 schema_url=schema_url,
@@ -81,7 +84,7 @@ class SchemaLoader:
         self._validate_schema_structure(schema, schema_url)
 
         # Update allowlist fingerprint
-        if self.allowlist_manager:
+        if self.allowlist_manager and not is_local_file:
             self.allowlist_manager.update_fingerprint(schema_url, json.dumps(schema, sort_keys=True))
 
         # Cache if enabled

--- a/its_compiler/security/config.py
+++ b/its_compiler/security/config.py
@@ -180,6 +180,9 @@ class SecurityConfig:
             config.processing.max_nesting_depth = int(max_depth)
 
         # Feature toggles
+        if os.getenv("ITS_ALLOW_LOCAL_SCHEMAS") == "true":
+            config.allow_local_schemas()
+
         if os.getenv("ITS_DISABLE_ALLOWLIST") == "true":
             config.enable_allowlist = False
 
@@ -190,6 +193,16 @@ class SecurityConfig:
             config.enable_expression_sanitisation = False
 
         return config
+
+    def allow_local_schemas(self) -> None:
+        """Permit extends to resolve local file paths relative to the template.
+
+        Local schemas are disabled by default; enable via this method or the
+        ITS_ALLOW_LOCAL_SCHEMAS environment variable when developing
+        unpublished type libraries.
+        """
+        self.network.allowed_protocols = set(self.network.allowed_protocols) | {"file"}
+        self.network.block_file_urls = False
 
     @classmethod
     def for_development(cls) -> "SecurityConfig":

--- a/its_compiler/security/expression_sanitiser.py
+++ b/its_compiler/security/expression_sanitiser.py
@@ -88,6 +88,11 @@ class ExpressionSanitiser:
     def sanitise_expression(self, expression: str, variables: Dict[str, Any]) -> str:
         """Sanitise and validate a conditional expression."""
 
+        from ..core.expression_utils import translate_condition_operators
+
+        # Rewrite the specification's &&, || and ! operators for Python parsing
+        expression = translate_condition_operators(expression)
+
         # Basic length and structure checks
         self._validate_basic_structure(expression)
 

--- a/its_compiler/security/input_validator.py
+++ b/its_compiler/security/input_validator.py
@@ -363,9 +363,13 @@ class InputValidator:
                     "invalid_extension_type",
                 )
 
-            # Basic URL validation (detailed validation done by URL validator)
+            # Basic URL validation (detailed validation done by URL validator).
+            # Scheme-less references are relative to the template and are
+            # validated after resolution; explicit non-http schemes and
+            # protocol-relative URLs are rejected here.
             if not re.match(r"^https?://", url):
-                self._security_violation(f"Invalid extension URL: {url}", "extends", "invalid_extension_url")
+                if re.match(r"^[a-zA-Z][a-zA-Z0-9+.\-]*:", url) or url.startswith("//"):
+                    self._security_violation(f"Invalid extension URL: {url}", "extends", "invalid_extension_url")
 
     def _validate_custom_types(self, custom_types: Dict[str, Any]) -> None:
         """Validate custom instruction types."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "its-compiler"
-version = "1.0.4"
+version = "1.1.0"
 description = "Reference Python library for Instruction Template Specification (ITS) with comprehensive security features"
 readme = { file = "README.md", content-type = "text/markdown" }
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -180,6 +180,8 @@ extend-ignore = [
     "E203", # Whitespace before ':' (conflicts with black)
     "W503", # Line break before binary operator (conflicts with black)
     "E501", # Line too long (handled by black)
+    "B042", # Exception __init__ kwargs; flagged across existing exception classes by newer bugbear releases
+
     "D100",
     "D101",
     "D102",

--- a/test/core/test_expression_utils.py
+++ b/test/core/test_expression_utils.py
@@ -1,0 +1,39 @@
+"""Tests for condition operator translation."""
+
+from its_compiler.core.conditional_evaluator import ConditionalEvaluator
+from its_compiler.core.expression_utils import translate_condition_operators
+
+
+class TestTranslateConditionOperators:
+    def test_translates_logical_and(self) -> None:
+        assert translate_condition_operators("a == true && b > 3") == "a == true  and  b > 3"
+
+    def test_translates_logical_or(self) -> None:
+        assert translate_condition_operators("a || b") == "a  or  b"
+
+    def test_translates_unary_not(self) -> None:
+        assert translate_condition_operators("!includeSpecs") == "not includeSpecs"
+
+    def test_preserves_not_equals(self) -> None:
+        assert translate_condition_operators("a != 'x'") == "a != 'x'"
+
+    def test_preserves_string_literals(self) -> None:
+        assert translate_condition_operators("name == 'a && b'") == "name == 'a && b'"
+
+    def test_idempotent_on_python_operators(self) -> None:
+        expression = "a == True and not b or c in ['x']"
+        assert translate_condition_operators(expression) == expression
+
+
+class TestSpecOperatorEvaluation:
+    """The spec's documented operators evaluate end to end."""
+
+    def test_compound_and(self) -> None:
+        evaluator = ConditionalEvaluator()
+        assert evaluator.evaluate_condition("a == true && b > 3", {"a": True, "b": 5}) is True
+        assert evaluator.evaluate_condition("a == true && b > 3", {"a": True, "b": 1}) is False
+
+    def test_compound_or_and_negation(self) -> None:
+        evaluator = ConditionalEvaluator()
+        assert evaluator.evaluate_condition("!a || b == 'x'", {"a": False, "b": "y"}) is True
+        assert evaluator.evaluate_condition("!a || b == 'x'", {"a": True, "b": "y"}) is False

--- a/test/fixtures/type_libraries/html-types-template.json
+++ b/test/fixtures/type_libraries/html-types-template.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://alexanderparker.github.io/instruction-template-specification/schema/v1.0/its-base-schema-v1.json",
+  "version": "1.0.0",
+  "extends": ["./its-html-types-v1.json"],
+  "variables": {
+    "productName": "Solar Garden Lantern"
+  },
+  "content": [
+    { "type": "text", "text": "<section>\n" },
+    {
+      "type": "placeholder",
+      "instructionType": "html_fragment",
+      "config": {
+        "description": "A summary paragraph for the ${productName}",
+        "rootElement": "p",
+        "includeClasses": true
+      }
+    },
+    { "type": "text", "text": "\nDefaults only:\n" },
+    {
+      "type": "placeholder",
+      "instructionType": "html_list",
+      "config": {
+        "description": "Key features of the ${productName}"
+      }
+    },
+    { "type": "text", "text": "\n</section>" }
+  ]
+}

--- a/test/fixtures/type_libraries/its-html-types-v1.json
+++ b/test/fixtures/type_libraries/its-html-types-v1.json
@@ -1,0 +1,103 @@
+{
+  "$schema": "https://alexanderparker.github.io/instruction-template-specification/schema/v1.0/its-type-extension-schema-v1.json",
+  "$id": "https://alexanderparker.github.io/instruction-template-specification/schema/v1.0/its-html-types-v1.json",
+  "title": "Instruction Template Specification - HTML Types v1.0",
+  "description": "Type library for generating raw HTML fragments that slot into surrounding static markup; never full documents",
+  "version": "1.0.0",
+  "instructionTypes": {
+    "html_fragment": {
+      "template": "<<Replace this placeholder with an HTML fragment using this user prompt: ([{<{description}>}]). Format requirements: Produce an HTML fragment consisting of one container element and its contents. Do not include a doctype or html, head or body tags. Include class attributes on elements: {includeClasses}. Output raw, valid HTML only - no markdown code fences, no surrounding commentary, and no explanation.>>",
+      "description": "Generates an HTML fragment with a single container element, with an optional preferred root element",
+      "configSchema": {
+        "type": "object",
+        "properties": {
+          "rootElement": {
+            "type": "string",
+            "description": "If specified, the tag name to use for the fragment's container element, for example div or article"
+          },
+          "includeClasses": {
+            "type": "boolean",
+            "default": true
+          }
+        }
+      }
+    },
+    "html_table": {
+      "template": "<<Replace this placeholder with an HTML table using this user prompt: ([{<{description}>}]). Format requirements: Produce a complete table element. Include a header row: {includeHeader}. Do not include a doctype or html, head or body tags. Output raw, valid HTML only - no markdown code fences, no surrounding commentary, and no explanation.>>",
+      "description": "Generates a complete HTML table with optional dimensions and a configurable header row",
+      "configSchema": {
+        "type": "object",
+        "properties": {
+          "columns": {
+            "type": "integer",
+            "minimum": 2,
+            "maximum": 10,
+            "description": "If specified, the number of columns"
+          },
+          "rows": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 50,
+            "description": "If specified, the number of rows"
+          },
+          "includeHeader": {
+            "type": "boolean",
+            "default": true
+          }
+        }
+      },
+      "examples": [
+        {
+          "config": {
+            "description": "A comparison of three broadband plans by speed, price and contract length",
+            "includeHeader": true
+          },
+          "output": "<<Replace this placeholder with an HTML table using this user prompt: ([{<A comparison of three broadband plans by speed, price and contract length>}]). Format requirements: Produce a complete table element. Include a header row: true. Do not include a doctype or html, head or body tags. Output raw, valid HTML only - no markdown code fences, no surrounding commentary, and no explanation.>>"
+        }
+      ]
+    },
+    "html_list": {
+      "template": "<<Replace this placeholder with an HTML list using this user prompt: ([{<{description}>}]). Format requirements: Produce one {listType} list element (unordered=ul, ordered=ol, description=dl). Do not include a doctype or html, head or body tags. Output raw, valid HTML only - no markdown code fences, no surrounding commentary, and no explanation.>>",
+      "description": "Generates an HTML list element of a configurable list type with an optional item count",
+      "configSchema": {
+        "type": "object",
+        "properties": {
+          "listType": {
+            "type": "string",
+            "enum": [
+              "unordered",
+              "ordered",
+              "description"
+            ],
+            "default": "unordered"
+          },
+          "itemCount": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 20,
+            "description": "If specified, the exact number of items to generate"
+          }
+        }
+      }
+    },
+    "html_form_fields": {
+      "template": "<<Replace this placeholder with HTML form fields using this user prompt: ([{<{description}>}]). Format requirements: Produce a set of form field controls without a form wrapper element. Include a label element for each control: {includeLabels}. Do not include a doctype or html, head or body tags. Output raw, valid HTML only - no markdown code fences, no surrounding commentary, and no explanation.>>",
+      "description": "Generates form controls with labels, without the form wrapper element",
+      "configSchema": {
+        "type": "object",
+        "properties": {
+          "fieldCount": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 15,
+            "description": "If specified, the exact number of form fields to generate"
+          },
+          "includeLabels": {
+            "type": "boolean",
+            "default": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/fixtures/type_libraries/its-json-types-v1.json
+++ b/test/fixtures/type_libraries/its-json-types-v1.json
@@ -1,0 +1,104 @@
+{
+  "$schema": "https://alexanderparker.github.io/instruction-template-specification/schema/v1.0/its-type-extension-schema-v1.json",
+  "$id": "https://alexanderparker.github.io/instruction-template-specification/schema/v1.0/its-json-types-v1.json",
+  "title": "Instruction Template Specification - JSON Types v1.0",
+  "description": "Type library for generating raw JSON output such as values, objects, arrays and JSON Schema documents",
+  "version": "1.0.0",
+  "instructionTypes": {
+    "json_value": {
+      "template": "<<Replace this placeholder with a single JSON value using this user prompt: ([{<{description}>}]). Format requirements: Produce one JSON value of type {valueType} (any means use whichever JSON type best fits the prompt). Output raw, valid JSON only - no markdown code fences, no surrounding commentary, and no explanation.>>",
+      "description": "Generates a single JSON value of a configurable type",
+      "configSchema": {
+        "type": "object",
+        "properties": {
+          "valueType": {
+            "type": "string",
+            "enum": [
+              "string",
+              "number",
+              "boolean",
+              "array",
+              "object",
+              "any"
+            ],
+            "default": "any"
+          }
+        }
+      }
+    },
+    "json_object": {
+      "template": "<<Replace this placeholder with a JSON object using this user prompt: ([{<{description}>}]). Format requirements: Produce a complete JSON object using {indent} indentation (compact=a single line with no unnecessary whitespace, two_spaces=pretty-printed with two-space indentation). Output raw, valid JSON only - no markdown code fences, no surrounding commentary, and no explanation.>>",
+      "description": "Generates a complete JSON object with configurable indentation",
+      "configSchema": {
+        "type": "object",
+        "properties": {
+          "indent": {
+            "type": "string",
+            "enum": [
+              "compact",
+              "two_spaces"
+            ],
+            "default": "two_spaces"
+          }
+        }
+      },
+      "examples": [
+        {
+          "config": {
+            "description": "A product record with id, name, price and inStock fields",
+            "indent": "two_spaces"
+          },
+          "output": "<<Replace this placeholder with a JSON object using this user prompt: ([{<A product record with id, name, price and inStock fields>}]). Format requirements: Produce a complete JSON object using two_spaces indentation (compact=a single line with no unnecessary whitespace, two_spaces=pretty-printed with two-space indentation). Output raw, valid JSON only - no markdown code fences, no surrounding commentary, and no explanation.>>"
+        }
+      ]
+    },
+    "json_array": {
+      "template": "<<Replace this placeholder with a JSON array using this user prompt: ([{<{description}>}]). Format requirements: Produce a JSON array using {indent} indentation (compact=a single line with no unnecessary whitespace, two_spaces=pretty-printed with two-space indentation). Output raw, valid JSON only - no markdown code fences, no surrounding commentary, and no explanation.>>",
+      "description": "Generates a JSON array with configurable indentation and an optional item count",
+      "configSchema": {
+        "type": "object",
+        "properties": {
+          "itemCount": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 50,
+            "description": "If specified, the exact number of items to generate"
+          },
+          "indent": {
+            "type": "string",
+            "enum": [
+              "compact",
+              "two_spaces"
+            ],
+            "default": "two_spaces"
+          }
+        }
+      }
+    },
+    "json_schema": {
+      "template": "<<Replace this placeholder with a JSON Schema document using this user prompt: ([{<{description}>}]). Format requirements: Produce a JSON Schema document that targets the {draft} draft, using {indent} indentation (compact=a single line with no unnecessary whitespace, two_spaces=pretty-printed with two-space indentation). Output raw, valid JSON only - no markdown code fences, no surrounding commentary, and no explanation.>>",
+      "description": "Generates a JSON Schema document describing a structure, targeting a configurable draft",
+      "configSchema": {
+        "type": "object",
+        "properties": {
+          "draft": {
+            "type": "string",
+            "enum": [
+              "draft-07",
+              "2020-12"
+            ],
+            "default": "2020-12"
+          },
+          "indent": {
+            "type": "string",
+            "enum": [
+              "compact",
+              "two_spaces"
+            ],
+            "default": "two_spaces"
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/fixtures/type_libraries/its-yaml-types-v1.json
+++ b/test/fixtures/type_libraries/its-yaml-types-v1.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "https://alexanderparker.github.io/instruction-template-specification/schema/v1.0/its-type-extension-schema-v1.json",
+  "$id": "https://alexanderparker.github.io/instruction-template-specification/schema/v1.0/its-yaml-types-v1.json",
+  "title": "Instruction Template Specification - YAML Types v1.0",
+  "description": "Type library for generating raw YAML output such as blocks, complete documents and markdown frontmatter",
+  "version": "1.0.0",
+  "instructionTypes": {
+    "yaml_block": {
+      "template": "<<Replace this placeholder with a YAML block using this user prompt: ([{<{description}>}]). Format requirements: Produce a valid YAML mapping or sequence fragment using {indentSize}-space indentation. Output raw, valid YAML only - no markdown code fences, no surrounding commentary, and no explanation.>>",
+      "description": "Generates a valid YAML mapping or sequence fragment with configurable indentation",
+      "configSchema": {
+        "type": "object",
+        "properties": {
+          "indentSize": {
+            "type": "integer",
+            "enum": [
+              2,
+              4
+            ],
+            "default": 2
+          }
+        }
+      }
+    },
+    "yaml_document": {
+      "template": "<<Replace this placeholder with a YAML document using this user prompt: ([{<{description}>}]). Format requirements: Produce a complete YAML document that begins with the --- document marker, using {indentSize}-space indentation. Use anchors and aliases for repeated values: {useAnchors}. Output raw, valid YAML only - no markdown code fences, no surrounding commentary, and no explanation.>>",
+      "description": "Generates a complete YAML document including the leading document marker",
+      "configSchema": {
+        "type": "object",
+        "properties": {
+          "indentSize": {
+            "type": "integer",
+            "enum": [
+              2,
+              4
+            ],
+            "default": 2
+          },
+          "useAnchors": {
+            "type": "boolean",
+            "default": false
+          }
+        }
+      },
+      "examples": [
+        {
+          "config": {
+            "description": "A CI pipeline with build and test jobs for a Node.js project",
+            "indentSize": 2,
+            "useAnchors": false
+          },
+          "output": "<<Replace this placeholder with a YAML document using this user prompt: ([{<A CI pipeline with build and test jobs for a Node.js project>}]). Format requirements: Produce a complete YAML document that begins with the --- document marker, using 2-space indentation. Use anchors and aliases for repeated values: false. Output raw, valid YAML only - no markdown code fences, no surrounding commentary, and no explanation.>>"
+        }
+      ]
+    },
+    "yaml_frontmatter": {
+      "template": "<<Replace this placeholder with a YAML frontmatter block using this user prompt: ([{<{description}>}]). Format requirements: Produce a frontmatter block for a markdown file: a YAML mapping wrapped in --- delimiters on the lines immediately before and after it. Output raw, valid YAML only - no markdown code fences, no surrounding commentary, and no explanation.>>",
+      "description": "Generates a YAML frontmatter block for markdown files, wrapped in delimiters, with an optional field count",
+      "configSchema": {
+        "type": "object",
+        "properties": {
+          "fieldCount": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 20,
+            "description": "If specified, the exact number of fields to generate"
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/fixtures/type_libraries/json-types-template.json
+++ b/test/fixtures/type_libraries/json-types-template.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://alexanderparker.github.io/instruction-template-specification/schema/v1.0/its-base-schema-v1.json",
+  "version": "1.0.0",
+  "extends": ["./its-json-types-v1.json"],
+  "variables": {
+    "resourceName": "orders",
+    "includeErrorExample": true
+  },
+  "content": [
+    { "type": "text", "text": "Example response:\n" },
+    {
+      "type": "placeholder",
+      "instructionType": "json_object",
+      "config": {
+        "description": "A ${resourceName} API response object",
+        "indent": "two_spaces"
+      }
+    },
+    {
+      "type": "conditional",
+      "condition": "includeErrorExample == true",
+      "content": [
+        { "type": "text", "text": "\nError response:\n" },
+        {
+          "type": "placeholder",
+          "instructionType": "json_object",
+          "config": {
+            "description": "A not_found error object for ${resourceName}",
+            "indent": "compact"
+          }
+        }
+      ]
+    },
+    { "type": "text", "text": "\nDefaults only:\n" },
+    {
+      "type": "placeholder",
+      "instructionType": "json_schema",
+      "config": {
+        "description": "A schema for the response above"
+      }
+    }
+  ]
+}

--- a/test/fixtures/type_libraries/yaml-types-template.json
+++ b/test/fixtures/type_libraries/yaml-types-template.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://alexanderparker.github.io/instruction-template-specification/schema/v1.0/its-base-schema-v1.json",
+  "version": "1.0.0",
+  "extends": ["./its-yaml-types-v1.json"],
+  "variables": {
+    "projectName": "example-storefront"
+  },
+  "content": [
+    { "type": "text", "text": "# CI configuration\n" },
+    {
+      "type": "placeholder",
+      "instructionType": "yaml_document",
+      "config": {
+        "description": "A CI pipeline for ${projectName}",
+        "indentSize": 2,
+        "useAnchors": false
+      }
+    },
+    { "type": "text", "text": "\nDefaults only:\n" },
+    {
+      "type": "placeholder",
+      "instructionType": "yaml_block",
+      "config": {
+        "description": "A deploy job for ${projectName}"
+      }
+    }
+  ]
+}

--- a/test/integration/test_type_libraries.py
+++ b/test/integration/test_type_libraries.py
@@ -1,0 +1,120 @@
+"""
+Integration tests for the published structured-output type libraries.
+
+Local fixture copies of the JSON, HTML and YAML libraries are loaded through
+relative extends with local schemas enabled, so no network is involved.
+"""
+
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import pytest
+
+from its_compiler import ITSCompiler
+from its_compiler.security import SecurityConfig
+
+FIXTURES = Path(__file__).parent.parent / "fixtures" / "type_libraries"
+
+RAW_OUTPUT_CLAUSES = {
+    "json": "Output raw, valid JSON only - no markdown code fences, no surrounding commentary, and no explanation.",
+    "html": "Output raw, valid HTML only - no markdown code fences, no surrounding commentary, and no explanation.",
+    "yaml": "Output raw, valid YAML only - no markdown code fences, no surrounding commentary, and no explanation.",
+}
+
+PUBLISHED_BASE = "https://alexanderparker.github.io/instruction-template-specification/schema/v1.0"
+
+
+def local_compiler() -> ITSCompiler:
+    security = SecurityConfig()
+    security.allow_local_schemas()
+    security.allowlist.interactive_mode = False
+    return ITSCompiler(security_config=security)
+
+
+def compile_fixture(name: str, variables: Optional[Dict[str, Any]] = None) -> str:
+    result = local_compiler().compile_file(str(FIXTURES / name), variables)
+    return str(result.prompt)
+
+
+class TestTypeLibrarySecurity:
+    """The published library URLs are trusted; local files are opt-in."""
+
+    def test_published_urls_pass_default_validation(self) -> None:
+        from its_compiler.security import AllowlistManager, URLValidator
+
+        config = SecurityConfig()
+        validator = URLValidator(config)
+        allowlist = AllowlistManager(config)
+
+        for file_name in ["its-json-types-v1.json", "its-html-types-v1.json", "its-yaml-types-v1.json"]:
+            url = f"{PUBLISHED_BASE}/{file_name}"
+            validator.validate_url(url)
+            assert allowlist._is_builtin_trusted(url)
+
+    def test_local_file_schemas_blocked_by_default(self) -> None:
+        security = SecurityConfig()
+        security.allowlist.interactive_mode = False
+        compiler = ITSCompiler(security_config=security)
+
+        with pytest.raises(Exception):
+            compiler.compile_file(str(FIXTURES / "json-types-template.json"))
+
+    def test_relative_extends_accepted_by_input_validation(self) -> None:
+        # Compiles cleanly with local schemas enabled and input validation on
+        prompt = compile_fixture("json-types-template.json")
+        assert "<<" in prompt
+
+
+class TestJsonTypeLibrary:
+    def test_raw_output_clause_and_escaping(self) -> None:
+        prompt = compile_fixture("json-types-template.json")
+
+        assert RAW_OUTPUT_CLAUSES["json"] in prompt
+        assert "([{<A orders API response object>}])" in prompt
+        assert "two_spaces indentation" in prompt
+
+    def test_conditionals_follow_variables(self) -> None:
+        with_error = compile_fixture("json-types-template.json")
+        assert "not_found error object" in with_error
+
+        without_error = compile_fixture("json-types-template.json", {"includeErrorExample": False})
+        assert "not_found error object" not in without_error
+
+    def test_defaults_render_when_config_omitted(self) -> None:
+        # The json_schema placeholder sets only a description
+        prompt = compile_fixture("json-types-template.json")
+
+        assert "targets the 2020-12 draft" in prompt
+        assert "{draft}" not in prompt
+        assert "{indent}" not in prompt
+
+
+class TestHtmlTypeLibrary:
+    def test_raw_output_clause_and_fragment_wording(self) -> None:
+        prompt = compile_fixture("html-types-template.json")
+
+        assert RAW_OUTPUT_CLAUSES["html"] in prompt
+        assert "([{<A summary paragraph for the Solar Garden Lantern>}])" in prompt
+        assert "Do not include a doctype or html, head or body tags." in prompt
+
+    def test_defaults_and_boolean_rendering(self) -> None:
+        prompt = compile_fixture("html-types-template.json")
+
+        # html_list relies on the listType default
+        assert "unordered list element" in prompt
+        assert "{listType}" not in prompt
+        # Booleans render JSON-style, not Python-style
+        assert "Include class attributes on elements: true." in prompt
+        assert "True" not in prompt
+
+
+class TestYamlTypeLibrary:
+    def test_raw_output_clause_and_defaults(self) -> None:
+        prompt = compile_fixture("yaml-types-template.json")
+
+        assert RAW_OUTPUT_CLAUSES["yaml"] in prompt
+        assert "([{<A CI pipeline for example-storefront>}])" in prompt
+        # yaml_block relies on the indentSize default
+        assert "2-space indentation" in prompt
+        assert "{indentSize}" not in prompt
+        assert "Use anchors and aliases for repeated values: false." in prompt

--- a/test/integration/test_type_libraries.py
+++ b/test/integration/test_type_libraries.py
@@ -56,7 +56,9 @@ class TestTypeLibrarySecurity:
         security.allowlist.interactive_mode = False
         compiler = ITSCompiler(security_config=security)
 
-        with pytest.raises(ITSCompilationError, match="blocked by security policy"):
+        # The file schema is refused, so its types never load and the
+        # placeholder cannot resolve
+        with pytest.raises(ITSCompilationError, match="Unknown instruction type"):
             compiler.compile_file(str(FIXTURES / "json-types-template.json"))
 
     def test_relative_extends_accepted_by_input_validation(self) -> None:

--- a/test/integration/test_type_libraries.py
+++ b/test/integration/test_type_libraries.py
@@ -10,7 +10,7 @@ from typing import Any, Dict, Optional
 
 import pytest
 
-from its_compiler import ITSCompiler
+from its_compiler import ITSCompilationError, ITSCompiler
 from its_compiler.security import SecurityConfig
 
 FIXTURES = Path(__file__).parent.parent / "fixtures" / "type_libraries"
@@ -56,7 +56,7 @@ class TestTypeLibrarySecurity:
         security.allowlist.interactive_mode = False
         compiler = ITSCompiler(security_config=security)
 
-        with pytest.raises(Exception):
+        with pytest.raises(ITSCompilationError, match="blocked by security policy"):
             compiler.compile_file(str(FIXTURES / "json-types-template.json"))
 
     def test_relative_extends_accepted_by_input_validation(self) -> None:

--- a/test/security/test_input_validator.py
+++ b/test/security/test_input_validator.py
@@ -495,17 +495,28 @@ class TestInputValidator:
 
     def test_invalid_extension_url(self, input_validator: InputValidator) -> None:
         """Test invalid extension URL detection."""
+        for bad_url in ["ftp://example.com/schema.json", "data:application/json;base64,e30=", "//example.com/x.json"]:
+            template = {
+                "version": "1.0.0",
+                "content": [{"type": "text", "text": "test"}],
+                "extends": [bad_url],
+            }
+
+            with pytest.raises(InputSecurityError) as exc_info:
+                input_validator.validate_template(template)
+
+            assert "Invalid extension URL" in str(exc_info.value)
+            assert exc_info.value.reason == "invalid_extension_url"
+
+    def test_relative_extension_reference_allowed(self, input_validator: InputValidator) -> None:
+        """Scheme-less extends entries are relative references and pass input validation."""
         template = {
             "version": "1.0.0",
             "content": [{"type": "text", "text": "test"}],
-            "extends": ["not-a-url"],
+            "extends": ["./local-types.json", "../shared/types.json", "types/custom.json"],
         }
 
-        with pytest.raises(InputSecurityError) as exc_info:
-            input_validator.validate_template(template)
-
-        assert "Invalid extension URL" in str(exc_info.value)
-        assert exc_info.value.reason == "invalid_extension_url"
+        input_validator.validate_template(template)
 
     def test_custom_instruction_types_validation(self, input_validator: InputValidator, template_fetcher: Any) -> None:
         """Test custom instruction types validation using repository templates."""


### PR DESCRIPTION
Support and verification for the three new published type libraries (JSON, HTML, YAML), plus conformance fixes surfaced while validating the specification work.

## Changes

- **Spec condition operators**: the specification documents `&&`, `||` and `!` in conditional expressions, but conditions were parsed with Python's `ast`, so compound spec-style conditions raised syntax errors. Conditions are now translated to Python equivalents before parsing (string literals and `!=` untouched); Python-style `and`/`or`/`not` keep working, so existing templates are unaffected.
- **configSchema defaults**: `format_instruction` raised "Missing required configuration" for any substituted property a placeholder omitted, even when the type declared a default. Defaults are now merged beneath the supplied config. Booleans render JSON-style (`true`/`false`) rather than Python-style for consistency with the JavaScript compiler.
- **Relative extends and local schemas (opt-in)**: the input validator rejected every non-`https?://` extends entry, although the core compiler already resolves relative references against the template's location. Scheme-less entries are now treated as relative references (explicit non-http schemes and protocol-relative URLs stay rejected), and the resolved `file://` URL is only permitted when local schemas are explicitly enabled via `SecurityConfig.allow_local_schemas()` or `ITS_ALLOW_LOCAL_SCHEMAS=true`. Local file schemas bypass the remote-origin allowlist (they only load at all under the explicit opt-in); everything stays blocked by default.
- **Integration tests**: fixture templates extending local copies of each new library compile end to end, asserting the raw-output no-code-fences clause, `([{< >}])` escaping, conditional evaluation, defaults rendering and boolean formatting. A security test proves the published library URLs pass URL validation and the built-in trust patterns under the default config, and that local files are rejected without the opt-in.
- **README**: documents the four published libraries, the spec operators, defaults behaviour and the new environment variable.
- Version bumped to 1.1.0.

## Verification

Full suite: 297 tests passing (one existing input-validator test updated for the new relative-reference semantics, with added coverage for rejected schemes). black, isort, flake8 and mypy all clean.

## Release note

Publishing 1.1.0 to PyPI is left to the repo owner. its-compiler-cli needs no code change (it wraps this library), but its pinned minimum should move to `its-compiler>=1.1.0` when released.
