### PR TITLE
Update type library fixtures to position-aware fills

### DIFF
--- a/test/fixtures/type_libraries/html-types-template.json
+++ b/test/fixtures/type_libraries/html-types-template.json
@@ -6,24 +6,42 @@
     "productName": "Solar Garden Lantern"
   },
   "content": [
-    { "type": "text", "text": "<section>\n" },
+    { "type": "text", "text": "<section class=\"product-card\">\n  <p class=\"summary\">" },
+    {
+      "type": "placeholder",
+      "instructionType": "html_text",
+      "config": {
+        "description": "a summary of the ${productName}",
+        "allowInlineMarkup": true
+      }
+    },
+    { "type": "text", "text": "</p>\n  <ul>\n" },
+    {
+      "type": "placeholder",
+      "instructionType": "html_list_items",
+      "config": {
+        "description": "four features of the ${productName}",
+        "itemCount": 4
+      }
+    },
+    { "type": "text", "text": "\n  </ul>\n  <table>\n    <thead><tr><th>Specification</th><th>Value</th></tr></thead>\n    <tbody>\n" },
+    {
+      "type": "placeholder",
+      "instructionType": "html_table_rows",
+      "config": {
+        "description": "specification rows for the ${productName}",
+        "rows": 3,
+        "columns": 2
+      }
+    },
+    { "type": "text", "text": "\n    </tbody>\n  </table>\n  <div class=\"extras\">" },
     {
       "type": "placeholder",
       "instructionType": "html_fragment",
       "config": {
-        "description": "A summary paragraph for the ${productName}",
-        "rootElement": "p",
-        "includeClasses": true
+        "description": "a small call-to-action block for the ${productName}"
       }
     },
-    { "type": "text", "text": "\nDefaults only:\n" },
-    {
-      "type": "placeholder",
-      "instructionType": "html_list",
-      "config": {
-        "description": "Key features of the ${productName}"
-      }
-    },
-    { "type": "text", "text": "\n</section>" }
+    { "type": "text", "text": "</div>\n</section>" }
   ]
 }

--- a/test/fixtures/type_libraries/its-html-types-v1.json
+++ b/test/fixtures/type_libraries/its-html-types-v1.json
@@ -2,45 +2,16 @@
   "$schema": "https://alexanderparker.github.io/instruction-template-specification/schema/v1.0/its-type-extension-schema-v1.json",
   "$id": "https://alexanderparker.github.io/instruction-template-specification/schema/v1.0/its-html-types-v1.json",
   "title": "Instruction Template Specification - HTML Types v1.0",
-  "description": "Type library for generating raw HTML fragments that slot into surrounding static markup; never full documents",
+  "description": "Type library for filling positions inside HTML markup authored in the template; the template text carries the surrounding tags and attributes verbatim, never full documents",
   "version": "1.0.0",
   "instructionTypes": {
-    "html_fragment": {
-      "template": "<<Replace this placeholder with an HTML fragment using this user prompt: ([{<{description}>}]). Format requirements: Produce an HTML fragment consisting of one container element and its contents. Do not include a doctype or html, head or body tags. Include class attributes on elements: {includeClasses}. Output raw, valid HTML only - no markdown code fences, no surrounding commentary, and no explanation.>>",
-      "description": "Generates an HTML fragment with a single container element, with an optional preferred root element",
+    "html_text": {
+      "template": "<<Replace this placeholder with HTML text content using this user prompt: ([{<{description}>}]). Format requirements: Produce text content for the enclosing element without repeating or closing its tags, escaping HTML special characters in the text. Inline markup such as strong, em and a is allowed: {allowInlineMarkup}. Output raw, valid HTML only - no markdown code fences, no surrounding commentary, and no explanation.>>",
+      "description": "Generates text content for an element whose tags are authored in the template",
       "configSchema": {
         "type": "object",
         "properties": {
-          "rootElement": {
-            "type": "string",
-            "description": "If specified, the tag name to use for the fragment's container element, for example div or article"
-          },
-          "includeClasses": {
-            "type": "boolean",
-            "default": true
-          }
-        }
-      }
-    },
-    "html_table": {
-      "template": "<<Replace this placeholder with an HTML table using this user prompt: ([{<{description}>}]). Format requirements: Produce a complete table element. Include a header row: {includeHeader}. Do not include a doctype or html, head or body tags. Output raw, valid HTML only - no markdown code fences, no surrounding commentary, and no explanation.>>",
-      "description": "Generates a complete HTML table with optional dimensions and a configurable header row",
-      "configSchema": {
-        "type": "object",
-        "properties": {
-          "columns": {
-            "type": "integer",
-            "minimum": 2,
-            "maximum": 10,
-            "description": "If specified, the number of columns"
-          },
-          "rows": {
-            "type": "integer",
-            "minimum": 1,
-            "maximum": 50,
-            "description": "If specified, the number of rows"
-          },
-          "includeHeader": {
+          "allowInlineMarkup": {
             "type": "boolean",
             "default": true
           }
@@ -49,28 +20,32 @@
       "examples": [
         {
           "config": {
-            "description": "A comparison of three broadband plans by speed, price and contract length",
-            "includeHeader": true
+            "description": "a short marketing summary of the product",
+            "allowInlineMarkup": true
           },
-          "output": "<<Replace this placeholder with an HTML table using this user prompt: ([{<A comparison of three broadband plans by speed, price and contract length>}]). Format requirements: Produce a complete table element. Include a header row: true. Do not include a doctype or html, head or body tags. Output raw, valid HTML only - no markdown code fences, no surrounding commentary, and no explanation.>>"
+          "output": "<<Replace this placeholder with HTML text content using this user prompt: ([{<a short marketing summary of the product>}]). Format requirements: Produce text content for the enclosing element without repeating or closing its tags, escaping HTML special characters in the text. Inline markup such as strong, em and a is allowed: true. Output raw, valid HTML only - no markdown code fences, no surrounding commentary, and no explanation.>>"
         }
       ]
     },
-    "html_list": {
-      "template": "<<Replace this placeholder with an HTML list using this user prompt: ([{<{description}>}]). Format requirements: Produce one {listType} list element (unordered=ul, ordered=ol, description=dl). Do not include a doctype or html, head or body tags. Output raw, valid HTML only - no markdown code fences, no surrounding commentary, and no explanation.>>",
-      "description": "Generates an HTML list element of a configurable list type with an optional item count",
+    "html_fragment": {
+      "template": "<<Replace this placeholder with an HTML fragment using this user prompt: ([{<{description}>}]). Format requirements: Produce HTML elements valid at this position inside the enclosing element, without repeating or closing the enclosing element's tags. Do not include a doctype or html, head or body tags. Include class attributes on elements: {includeClasses}. Output raw, valid HTML only - no markdown code fences, no surrounding commentary, and no explanation.>>",
+      "description": "Generates child elements for a position inside markup authored in the template",
       "configSchema": {
         "type": "object",
         "properties": {
-          "listType": {
-            "type": "string",
-            "enum": [
-              "unordered",
-              "ordered",
-              "description"
-            ],
-            "default": "unordered"
-          },
+          "includeClasses": {
+            "type": "boolean",
+            "default": true
+          }
+        }
+      }
+    },
+    "html_list_items": {
+      "template": "<<Replace this placeholder with HTML list items using this user prompt: ([{<{description}>}]). Format requirements: Produce list item elements appropriate to the enclosing list (li elements for ul or ol, dt and dd pairs for dl), without the enclosing list tags. Output raw, valid HTML only - no markdown code fences, no surrounding commentary, and no explanation.>>",
+      "description": "Generates items for a list whose tags are authored in the template",
+      "configSchema": {
+        "type": "object",
+        "properties": {
           "itemCount": {
             "type": "integer",
             "minimum": 1,
@@ -80,9 +55,30 @@
         }
       }
     },
+    "html_table_rows": {
+      "template": "<<Replace this placeholder with HTML table rows using this user prompt: ([{<{description}>}]). Format requirements: Produce tr elements containing td cells, without the enclosing table, thead or tbody tags, matching the column structure of the surrounding table. Output raw, valid HTML only - no markdown code fences, no surrounding commentary, and no explanation.>>",
+      "description": "Generates rows for a table whose structure and header are authored in the template",
+      "configSchema": {
+        "type": "object",
+        "properties": {
+          "rows": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 50,
+            "description": "If specified, the exact number of rows to generate"
+          },
+          "columns": {
+            "type": "integer",
+            "minimum": 2,
+            "maximum": 10,
+            "description": "If specified, the number of cells per row"
+          }
+        }
+      }
+    },
     "html_form_fields": {
-      "template": "<<Replace this placeholder with HTML form fields using this user prompt: ([{<{description}>}]). Format requirements: Produce a set of form field controls without a form wrapper element. Include a label element for each control: {includeLabels}. Do not include a doctype or html, head or body tags. Output raw, valid HTML only - no markdown code fences, no surrounding commentary, and no explanation.>>",
-      "description": "Generates form controls with labels, without the form wrapper element",
+      "template": "<<Replace this placeholder with HTML form fields using this user prompt: ([{<{description}>}]). Format requirements: Produce form field controls valid at this position inside the enclosing form or container, without producing a form element. Include a label element for each control: {includeLabels}. Output raw, valid HTML only - no markdown code fences, no surrounding commentary, and no explanation.>>",
+      "description": "Generates labelled form controls for a position inside a form or container authored in the template",
       "configSchema": {
         "type": "object",
         "properties": {

--- a/test/fixtures/type_libraries/its-json-types-v1.json
+++ b/test/fixtures/type_libraries/its-json-types-v1.json
@@ -2,12 +2,42 @@
   "$schema": "https://alexanderparker.github.io/instruction-template-specification/schema/v1.0/its-type-extension-schema-v1.json",
   "$id": "https://alexanderparker.github.io/instruction-template-specification/schema/v1.0/its-json-types-v1.json",
   "title": "Instruction Template Specification - JSON Types v1.0",
-  "description": "Type library for generating raw JSON output such as values, objects, arrays and JSON Schema documents",
+  "description": "Type library for filling value positions inside JSON structure authored in the template; the template text carries the document's braces, field names and fixed values verbatim",
   "version": "1.0.0",
   "instructionTypes": {
+    "json_string": {
+      "template": "<<Replace this placeholder with a JSON string using this user prompt: ([{<{description}>}]). Format requirements: Produce a single JSON string literal including its surrounding double quotes, exactly as it must appear at this position in the enclosing JSON document. Output raw, valid JSON only - no markdown code fences, no surrounding commentary, and no explanation.>>",
+      "description": "Generates a single JSON string literal, quotes included, for a value position authored in the template",
+      "examples": [
+        {
+          "config": {
+            "description": "a plausible order id such as ord_8f3k2q"
+          },
+          "output": "<<Replace this placeholder with a JSON string using this user prompt: ([{<a plausible order id such as ord_8f3k2q>}]). Format requirements: Produce a single JSON string literal including its surrounding double quotes, exactly as it must appear at this position in the enclosing JSON document. Output raw, valid JSON only - no markdown code fences, no surrounding commentary, and no explanation.>>"
+        }
+      ]
+    },
+    "json_number": {
+      "template": "<<Replace this placeholder with a JSON number using this user prompt: ([{<{description}>}]). Format requirements: Produce a single JSON number literal of kind {numberType} (integer=a whole number, decimal=may have a fractional part, any=whichever kind fits the prompt), without quotes, exactly as it must appear at this position in the enclosing JSON document. Output raw, valid JSON only - no markdown code fences, no surrounding commentary, and no explanation.>>",
+      "description": "Generates a single JSON number literal for a value position authored in the template",
+      "configSchema": {
+        "type": "object",
+        "properties": {
+          "numberType": {
+            "type": "string",
+            "enum": [
+              "integer",
+              "decimal",
+              "any"
+            ],
+            "default": "any"
+          }
+        }
+      }
+    },
     "json_value": {
-      "template": "<<Replace this placeholder with a single JSON value using this user prompt: ([{<{description}>}]). Format requirements: Produce one JSON value of type {valueType} (any means use whichever JSON type best fits the prompt). Output raw, valid JSON only - no markdown code fences, no surrounding commentary, and no explanation.>>",
-      "description": "Generates a single JSON value of a configurable type",
+      "template": "<<Replace this placeholder with a JSON value using this user prompt: ([{<{description}>}]). Format requirements: Produce a single JSON value of type {valueType} (any means use whichever JSON type best fits the prompt), exactly as it must appear at this position in the enclosing JSON document. Output raw, valid JSON only - no markdown code fences, no surrounding commentary, and no explanation.>>",
+      "description": "Generates a single JSON value of a configurable type for a value position authored in the template",
       "configSchema": {
         "type": "object",
         "properties": {
@@ -26,76 +56,44 @@
         }
       }
     },
-    "json_object": {
-      "template": "<<Replace this placeholder with a JSON object using this user prompt: ([{<{description}>}]). Format requirements: Produce a complete JSON object using {indent} indentation (compact=a single line with no unnecessary whitespace, two_spaces=pretty-printed with two-space indentation). Output raw, valid JSON only - no markdown code fences, no surrounding commentary, and no explanation.>>",
-      "description": "Generates a complete JSON object with configurable indentation",
+    "json_array_items": {
+      "template": "<<Replace this placeholder with JSON array items using this user prompt: ([{<{description}>}]). Format requirements: Produce JSON array items separated by commas, without the enclosing square brackets, each item of type {itemType} (any means use whichever JSON type best fits the prompt), valid inside the surrounding array in the enclosing JSON document. Output raw, valid JSON only - no markdown code fences, no surrounding commentary, and no explanation.>>",
+      "description": "Generates comma-separated items for an array whose brackets are authored in the template",
       "configSchema": {
         "type": "object",
         "properties": {
-          "indent": {
+          "itemType": {
             "type": "string",
             "enum": [
-              "compact",
-              "two_spaces"
+              "string",
+              "number",
+              "boolean",
+              "object",
+              "array",
+              "any"
             ],
-            "default": "two_spaces"
-          }
-        }
-      },
-      "examples": [
-        {
-          "config": {
-            "description": "A product record with id, name, price and inStock fields",
-            "indent": "two_spaces"
+            "default": "any"
           },
-          "output": "<<Replace this placeholder with a JSON object using this user prompt: ([{<A product record with id, name, price and inStock fields>}]). Format requirements: Produce a complete JSON object using two_spaces indentation (compact=a single line with no unnecessary whitespace, two_spaces=pretty-printed with two-space indentation). Output raw, valid JSON only - no markdown code fences, no surrounding commentary, and no explanation.>>"
-        }
-      ]
-    },
-    "json_array": {
-      "template": "<<Replace this placeholder with a JSON array using this user prompt: ([{<{description}>}]). Format requirements: Produce a JSON array using {indent} indentation (compact=a single line with no unnecessary whitespace, two_spaces=pretty-printed with two-space indentation). Output raw, valid JSON only - no markdown code fences, no surrounding commentary, and no explanation.>>",
-      "description": "Generates a JSON array with configurable indentation and an optional item count",
-      "configSchema": {
-        "type": "object",
-        "properties": {
           "itemCount": {
             "type": "integer",
             "minimum": 1,
             "maximum": 50,
             "description": "If specified, the exact number of items to generate"
-          },
-          "indent": {
-            "type": "string",
-            "enum": [
-              "compact",
-              "two_spaces"
-            ],
-            "default": "two_spaces"
           }
         }
       }
     },
-    "json_schema": {
-      "template": "<<Replace this placeholder with a JSON Schema document using this user prompt: ([{<{description}>}]). Format requirements: Produce a JSON Schema document that targets the {draft} draft, using {indent} indentation (compact=a single line with no unnecessary whitespace, two_spaces=pretty-printed with two-space indentation). Output raw, valid JSON only - no markdown code fences, no surrounding commentary, and no explanation.>>",
-      "description": "Generates a JSON Schema document describing a structure, targeting a configurable draft",
+    "json_object_fields": {
+      "template": "<<Replace this placeholder with JSON object fields using this user prompt: ([{<{description}>}]). Format requirements: Produce JSON object members separated by commas, each a double-quoted field name followed by a colon and a value, without the enclosing curly braces, valid inside the surrounding object in the enclosing JSON document. Output raw, valid JSON only - no markdown code fences, no surrounding commentary, and no explanation.>>",
+      "description": "Generates comma-separated members for an object whose braces are authored in the template",
       "configSchema": {
         "type": "object",
         "properties": {
-          "draft": {
-            "type": "string",
-            "enum": [
-              "draft-07",
-              "2020-12"
-            ],
-            "default": "2020-12"
-          },
-          "indent": {
-            "type": "string",
-            "enum": [
-              "compact",
-              "two_spaces"
-            ],
-            "default": "two_spaces"
+          "fieldCount": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 30,
+            "description": "If specified, the exact number of fields to generate"
           }
         }
       }

--- a/test/fixtures/type_libraries/its-yaml-types-v1.json
+++ b/test/fixtures/type_libraries/its-yaml-types-v1.json
@@ -2,68 +2,70 @@
   "$schema": "https://alexanderparker.github.io/instruction-template-specification/schema/v1.0/its-type-extension-schema-v1.json",
   "$id": "https://alexanderparker.github.io/instruction-template-specification/schema/v1.0/its-yaml-types-v1.json",
   "title": "Instruction Template Specification - YAML Types v1.0",
-  "description": "Type library for generating raw YAML output such as blocks, complete documents and markdown frontmatter",
+  "description": "Type library for filling value positions inside YAML structure authored in the template; the template text carries the document's keys, nesting and fixed values verbatim",
   "version": "1.0.0",
   "instructionTypes": {
-    "yaml_block": {
-      "template": "<<Replace this placeholder with a YAML block using this user prompt: ([{<{description}>}]). Format requirements: Produce a valid YAML mapping or sequence fragment using {indentSize}-space indentation. Output raw, valid YAML only - no markdown code fences, no surrounding commentary, and no explanation.>>",
-      "description": "Generates a valid YAML mapping or sequence fragment with configurable indentation",
+    "yaml_value": {
+      "template": "<<Replace this placeholder with a YAML value using this user prompt: ([{<{description}>}]). Format requirements: Produce a single YAML scalar value of type {valueType} (any means use whichever type best fits the prompt) on one line, exactly as it must appear at this position after the enclosing mapping key. Output raw, valid YAML only - no markdown code fences, no surrounding commentary, and no explanation.>>",
+      "description": "Generates a single YAML scalar value for a mapping key authored in the template",
       "configSchema": {
         "type": "object",
         "properties": {
-          "indentSize": {
-            "type": "integer",
+          "valueType": {
+            "type": "string",
             "enum": [
-              2,
-              4
+              "string",
+              "number",
+              "boolean",
+              "any"
             ],
-            "default": 2
+            "default": "any"
           }
         }
       }
     },
-    "yaml_document": {
-      "template": "<<Replace this placeholder with a YAML document using this user prompt: ([{<{description}>}]). Format requirements: Produce a complete YAML document that begins with the --- document marker, using {indentSize}-space indentation. Use anchors and aliases for repeated values: {useAnchors}. Output raw, valid YAML only - no markdown code fences, no surrounding commentary, and no explanation.>>",
-      "description": "Generates a complete YAML document including the leading document marker",
+    "yaml_list_items": {
+      "template": "<<Replace this placeholder with YAML list items using this user prompt: ([{<{description}>}]). Format requirements: Produce YAML sequence items, one per line, each line beginning with {indentSpaces} spaces followed by a hyphen and a space, valid at this position in the enclosing YAML document. Output raw, valid YAML only - no markdown code fences, no surrounding commentary, and no explanation.>>",
+      "description": "Generates sequence items at a stated indent for a list whose key is authored in the template",
       "configSchema": {
         "type": "object",
         "properties": {
-          "indentSize": {
+          "indentSpaces": {
             "type": "integer",
-            "enum": [
-              2,
-              4
-            ],
+            "minimum": 0,
+            "maximum": 20,
             "default": 2
           },
-          "useAnchors": {
-            "type": "boolean",
-            "default": false
+          "itemCount": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 50,
+            "description": "If specified, the exact number of items to generate"
           }
         }
       },
       "examples": [
         {
           "config": {
-            "description": "A CI pipeline with build and test jobs for a Node.js project",
-            "indentSize": 2,
-            "useAnchors": false
+            "description": "commands that install dependencies and run the tests",
+            "indentSpaces": 4,
+            "itemCount": 2
           },
-          "output": "<<Replace this placeholder with a YAML document using this user prompt: ([{<A CI pipeline with build and test jobs for a Node.js project>}]). Format requirements: Produce a complete YAML document that begins with the --- document marker, using 2-space indentation. Use anchors and aliases for repeated values: false. Output raw, valid YAML only - no markdown code fences, no surrounding commentary, and no explanation.>>"
+          "output": "<<Replace this placeholder with YAML list items using this user prompt: ([{<commands that install dependencies and run the tests>}]). Format requirements: Produce YAML sequence items, one per line, each line beginning with 4 spaces followed by a hyphen and a space, valid at this position in the enclosing YAML document. Output raw, valid YAML only - no markdown code fences, no surrounding commentary, and no explanation.>>"
         }
       ]
     },
-    "yaml_frontmatter": {
-      "template": "<<Replace this placeholder with a YAML frontmatter block using this user prompt: ([{<{description}>}]). Format requirements: Produce a frontmatter block for a markdown file: a YAML mapping wrapped in --- delimiters on the lines immediately before and after it. Output raw, valid YAML only - no markdown code fences, no surrounding commentary, and no explanation.>>",
-      "description": "Generates a YAML frontmatter block for markdown files, wrapped in delimiters, with an optional field count",
+    "yaml_block": {
+      "template": "<<Replace this placeholder with a YAML block using this user prompt: ([{<{description}>}]). Format requirements: Produce a YAML mapping or sequence fragment with every line indented by {indentSpaces} spaces, valid at this position in the enclosing YAML document. Output raw, valid YAML only - no markdown code fences, no surrounding commentary, and no explanation.>>",
+      "description": "Generates an indented mapping or sequence fragment under a parent key authored in the template",
       "configSchema": {
         "type": "object",
         "properties": {
-          "fieldCount": {
+          "indentSpaces": {
             "type": "integer",
-            "minimum": 1,
+            "minimum": 0,
             "maximum": 20,
-            "description": "If specified, the exact number of fields to generate"
+            "default": 2
           }
         }
       }

--- a/test/fixtures/type_libraries/json-types-template.json
+++ b/test/fixtures/type_libraries/json-types-template.json
@@ -7,37 +7,48 @@
     "includeErrorExample": true
   },
   "content": [
-    { "type": "text", "text": "Example response:\n" },
+    { "type": "text", "text": "{\n  \"data\": [\n" },
     {
       "type": "placeholder",
-      "instructionType": "json_object",
+      "instructionType": "json_array_items",
       "config": {
-        "description": "A ${resourceName} API response object",
-        "indent": "two_spaces"
+        "description": "three ${resourceName} objects with id and status fields",
+        "itemType": "object",
+        "itemCount": 3
       }
     },
+    { "type": "text", "text": "\n  ],\n  \"page\": 1,\n  \"total\": " },
+    {
+      "type": "placeholder",
+      "instructionType": "json_number",
+      "config": {
+        "description": "a plausible total count of ${resourceName}",
+        "numberType": "integer"
+      }
+    },
+    { "type": "text", "text": ",\n  \"summary\": " },
+    {
+      "type": "placeholder",
+      "instructionType": "json_value",
+      "config": {
+        "description": "a one-line summary of the ${resourceName} collection"
+      }
+    },
+    { "type": "text", "text": "\n}" },
     {
       "type": "conditional",
       "condition": "includeErrorExample == true",
       "content": [
-        { "type": "text", "text": "\nError response:\n" },
+        { "type": "text", "text": "\n\n{\n  \"error\": {\n    \"code\": \"not_found\",\n    \"message\": " },
         {
           "type": "placeholder",
-          "instructionType": "json_object",
+          "instructionType": "json_string",
           "config": {
-            "description": "A not_found error object for ${resourceName}",
-            "indent": "compact"
+            "description": "a message about a missing ${resourceName} resource"
           }
-        }
+        },
+        { "type": "text", "text": "\n  }\n}" }
       ]
-    },
-    { "type": "text", "text": "\nDefaults only:\n" },
-    {
-      "type": "placeholder",
-      "instructionType": "json_schema",
-      "config": {
-        "description": "A schema for the response above"
-      }
     }
   ]
 }

--- a/test/fixtures/type_libraries/yaml-types-template.json
+++ b/test/fixtures/type_libraries/yaml-types-template.json
@@ -6,22 +6,30 @@
     "projectName": "example-storefront"
   },
   "content": [
-    { "type": "text", "text": "# CI configuration\n" },
+    { "type": "text", "text": "# CI configuration\nimage: " },
     {
       "type": "placeholder",
-      "instructionType": "yaml_document",
+      "instructionType": "yaml_value",
       "config": {
-        "description": "A CI pipeline for ${projectName}",
-        "indentSize": 2,
-        "useAnchors": false
+        "description": "a container image for ${projectName}",
+        "valueType": "string"
       }
     },
-    { "type": "text", "text": "\nDefaults only:\n" },
+    { "type": "text", "text": "\n\nbuild:\n  script:\n" },
+    {
+      "type": "placeholder",
+      "instructionType": "yaml_list_items",
+      "config": {
+        "description": "commands that build ${projectName}",
+        "indentSpaces": 4
+      }
+    },
+    { "type": "text", "text": "\n\ndeploy:\n" },
     {
       "type": "placeholder",
       "instructionType": "yaml_block",
       "config": {
-        "description": "A deploy job for ${projectName}"
+        "description": "the fields of a deploy job for ${projectName}"
       }
     }
   ]

--- a/test/integration/test_type_libraries.py
+++ b/test/integration/test_type_libraries.py
@@ -1,8 +1,10 @@
 """
 Integration tests for the published structured-output type libraries.
 
-Local fixture copies of the JSON, HTML and YAML libraries are loaded through
-relative extends with local schemas enabled, so no network is involved.
+The libraries fill value positions inside structure authored verbatim in the
+template text. Local fixture copies of the JSON, HTML and YAML libraries are
+loaded through relative extends with local schemas enabled, so no network is
+involved.
 """
 
 from pathlib import Path
@@ -68,55 +70,61 @@ class TestTypeLibrarySecurity:
 
 
 class TestJsonTypeLibrary:
-    def test_raw_output_clause_and_escaping(self) -> None:
+    def test_authored_structure_verbatim_with_fills(self) -> None:
         prompt = compile_fixture("json-types-template.json")
 
+        # The document scaffolding comes from the template text, not the model
+        assert '{\n  "data": [\n' in prompt
+        assert '"page": 1,' in prompt
+        assert '"code": "not_found",' in prompt
+        # Fills carry the raw-output clause and escaped descriptions
         assert RAW_OUTPUT_CLAUSES["json"] in prompt
-        assert "([{<A orders API response object>}])" in prompt
-        assert "two_spaces indentation" in prompt
+        assert "([{<three orders objects with id and status fields>}])" in prompt
+        assert "without the enclosing square brackets" in prompt
+        assert "of kind integer" in prompt
 
     def test_conditionals_follow_variables(self) -> None:
         with_error = compile_fixture("json-types-template.json")
-        assert "not_found error object" in with_error
+        assert "not_found" in with_error
 
         without_error = compile_fixture("json-types-template.json", {"includeErrorExample": False})
-        assert "not_found error object" not in without_error
+        assert "not_found" not in without_error
 
     def test_defaults_render_when_config_omitted(self) -> None:
-        # The json_schema placeholder sets only a description
+        # The json_value placeholder sets only a description
         prompt = compile_fixture("json-types-template.json")
 
-        assert "targets the 2020-12 draft" in prompt
-        assert "{draft}" not in prompt
-        assert "{indent}" not in prompt
+        assert "of type any" in prompt
+        assert "{valueType}" not in prompt
+        assert "{numberType}" not in prompt
 
 
 class TestHtmlTypeLibrary:
-    def test_raw_output_clause_and_fragment_wording(self) -> None:
+    def test_authored_markup_verbatim_with_fills(self) -> None:
         prompt = compile_fixture("html-types-template.json")
 
+        assert '<section class="product-card">' in prompt
+        assert "<thead><tr><th>Specification</th><th>Value</th></tr></thead>" in prompt
         assert RAW_OUTPUT_CLAUSES["html"] in prompt
-        assert "([{<A summary paragraph for the Solar Garden Lantern>}])" in prompt
-        assert "Do not include a doctype or html, head or body tags." in prompt
-
-    def test_defaults_and_boolean_rendering(self) -> None:
-        prompt = compile_fixture("html-types-template.json")
-
-        # html_list relies on the listType default
-        assert "unordered list element" in prompt
-        assert "{listType}" not in prompt
+        assert "([{<a summary of the Solar Garden Lantern>}])" in prompt
+        assert "without the enclosing list tags" in prompt
+        assert "without the enclosing table, thead or tbody tags" in prompt
         # Booleans render JSON-style, not Python-style
+        assert "Inline markup such as strong, em and a is allowed: true." in prompt
+        # html_fragment placeholder relies on the includeClasses default
         assert "Include class attributes on elements: true." in prompt
+        assert "{includeClasses}" not in prompt
         assert "True" not in prompt
 
 
 class TestYamlTypeLibrary:
-    def test_raw_output_clause_and_defaults(self) -> None:
+    def test_authored_structure_verbatim_with_fills(self) -> None:
         prompt = compile_fixture("yaml-types-template.json")
 
+        assert "build:\n  script:\n" in prompt
         assert RAW_OUTPUT_CLAUSES["yaml"] in prompt
-        assert "([{<A CI pipeline for example-storefront>}])" in prompt
-        # yaml_block relies on the indentSize default
-        assert "2-space indentation" in prompt
-        assert "{indentSize}" not in prompt
-        assert "Use anchors and aliases for repeated values: false." in prompt
+        assert "([{<commands that build example-storefront>}])" in prompt
+        assert "beginning with 4 spaces followed by a hyphen" in prompt
+        # yaml_block placeholder relies on the indentSpaces default
+        assert "indented by 2 spaces" in prompt
+        assert "{indentSpaces}" not in prompt


### PR DESCRIPTION
Follows the spec redesign (instruction-template-specification PR #2): the structured-output libraries now fill value positions inside structure authored verbatim in template text. Updates the fixture library copies and templates and rewrites assertions accordingly. Full suite: 296 passing locally.