### PR TITLE
Reference data sections for tabular data sources

### DIFF
--- a/its_compiler/core/compiler.py
+++ b/its_compiler/core/compiler.py
@@ -20,6 +20,7 @@ from .models import (
     TypeOverride,
     ValidationResult,
 )
+from .reference_data import REFERENCE_DATA_INSTRUCTION, collect_data_source_names, render_data_source
 from .schema_loader import SchemaLoader
 from .variable_processor import VariableProcessor
 
@@ -133,7 +134,7 @@ class ITSCompiler:
         final_content = self._evaluate_conditionals(processed_content, merged_variables)
 
         # Generate final prompt
-        prompt = self._generate_prompt(final_content, instruction_types, template)
+        prompt = self._generate_prompt(final_content, instruction_types, template, merged_variables)
 
         # Validate final prompt
         self._validate_final_prompt(prompt)
@@ -417,17 +418,31 @@ class ITSCompiler:
         content: List[Dict[str, Any]],
         instruction_types: Dict[str, InstructionTypeDefinition],
         template: Dict[str, Any],
+        variables: Optional[Dict[str, Any]] = None,
     ) -> str:
         """Generate the final AI prompt."""
+        variables = variables or {}
 
         # Get compiler configuration
         compiler_config = template.get("compilerConfig", {})
         system_prompt = compiler_config.get("systemPrompt", self.config.default_system_prompt)
         user_content_wrapper = compiler_config.get("userContentWrapper", self.config.default_user_content_wrapper)
         instruction_wrapper = compiler_config.get("instructionWrapper", self.config.default_instruction_wrapper)
-        processing_instructions = compiler_config.get(
-            "processingInstructions", self.config.default_processing_instructions
+        processing_instructions = list(
+            compiler_config.get("processingInstructions", self.config.default_processing_instructions) or []
         )
+
+        # Reference data: variables named by placeholder dataSource configs are
+        # rendered once above the template as context the model must not output
+        data_source_names = collect_data_source_names(content)
+        reference_parts: List[str] = []
+        if data_source_names:
+            reference_parts.extend(["REFERENCE DATA", ""])
+            for name in data_source_names:
+                if name not in variables:
+                    raise ITSCompilationError(f"Unknown data source '{name}': no variable with that name")
+                reference_parts.extend([f"### {name}", "", render_data_source(variables[name]), ""])
+            processing_instructions.append(REFERENCE_DATA_INSTRUCTION)
 
         # Process content elements
         processed_content = []
@@ -450,10 +465,12 @@ class ITSCompiler:
         # Assemble final prompt
         prompt_parts = ["INTRODUCTION", "", system_prompt, "", "INSTRUCTIONS", ""]
 
-        for i, instruction in enumerate(processing_instructions or [], 1):
+        for i, instruction in enumerate(processing_instructions, 1):
             prompt_parts.append(f"{i}. {instruction}")
 
-        prompt_parts.extend(["", "TEMPLATE", "", "".join(processed_content)])
+        prompt_parts.append("")
+        prompt_parts.extend(reference_parts)
+        prompt_parts.extend(["TEMPLATE", "", "".join(processed_content)])
 
         return "\n".join(prompt_parts)
 

--- a/its_compiler/core/reference_data.py
+++ b/its_compiler/core/reference_data.py
@@ -1,0 +1,68 @@
+"""Reference data sections.
+
+A placeholder's config may name one or more data sources through the
+reserved ``dataSource`` key (a variable name or list of variable names).
+The compiler renders each referenced variable once in a REFERENCE DATA
+section above the template, so the model can ground generated content in
+the data without the data appearing in the rendered output; a processing
+instruction tells the model the section is context only.
+
+Rendering is kept byte-compatible with the JavaScript compiler.
+"""
+
+import json
+from typing import Any, Dict, List
+
+REFERENCE_DATA_INSTRUCTION = (
+    "Use the REFERENCE DATA section as context when generating placeholder content"
+    " - never include the reference data itself in your output"
+)
+
+
+def collect_data_source_names(content: List[Dict[str, Any]]) -> List[str]:
+    """Collect data source names from placeholder configs, deduplicated in order of first appearance."""
+    names: List[str] = []
+    for element in content:
+        if element.get("type") != "placeholder":
+            continue
+        raw = element.get("config", {}).get("dataSource")
+        candidates = [raw] if isinstance(raw, str) else raw if isinstance(raw, list) else []
+        for candidate in candidates:
+            if isinstance(candidate, str) and candidate and candidate not in names:
+                names.append(candidate)
+    return names
+
+
+def _render_cell(value: Any) -> str:
+    """Cell rendering: strings verbatim, everything else compact JSON."""
+    text = value if isinstance(value, str) else json.dumps(value, separators=(",", ":"))
+    return text.replace("|", "\\|").replace("\n", " ")
+
+
+def _render_object_table(rows: List[Dict[str, Any]]) -> str:
+    columns: List[str] = []
+    for row in rows:
+        for key in row.keys():
+            if key not in columns:
+                columns.append(key)
+    lines = [
+        "| " + " | ".join(columns) + " |",
+        "| " + " | ".join("---" for _ in columns) + " |",
+    ]
+    for row in rows:
+        lines.append("| " + " | ".join(_render_cell(row[c]) if c in row else "" for c in columns) + " |")
+    return "\n".join(lines)
+
+
+def render_data_source(value: Any) -> str:
+    """Render one data source as markdown: arrays of objects become tables, plain objects become field tables."""
+    if isinstance(value, list):
+        if value and all(isinstance(item, dict) for item in value):
+            return _render_object_table(value)
+        return "\n".join(f"- {_render_cell(item)}" for item in value)
+    if isinstance(value, dict):
+        lines = ["| Field | Value |", "| --- | --- |"]
+        for key, item in value.items():
+            lines.append(f"| {_render_cell(key)} | {_render_cell(item)} |")
+        return "\n".join(lines)
+    return _render_cell(value)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "its-compiler"
-version = "1.1.0"
+version = "1.2.0"
 description = "Reference Python library for Instruction Template Specification (ITS) with comprehensive security features"
 readme = { file = "README.md", content-type = "text/markdown" }
 license = "MIT"

--- a/test/core/test_reference_data.py
+++ b/test/core/test_reference_data.py
@@ -1,0 +1,120 @@
+"""Tests for reference data sections."""
+
+from typing import Any, Dict
+
+import pytest
+
+from its_compiler import ITSCompilationError, ITSCompiler
+from its_compiler.core.reference_data import REFERENCE_DATA_INSTRUCTION, render_data_source
+from its_compiler.security import SecurityConfig
+
+
+def forecast_template() -> Dict[str, Any]:
+    return {
+        "version": "1.0.0",
+        "customInstructionTypes": {
+            "summary": {
+                "template": "<<Summarise using this prompt: ([{<{description}>}]).>>",
+            }
+        },
+        "variables": {
+            "location": "Adelaide",
+            "forecast": [
+                {"day": "Monday", "high": 29, "wet": False},
+                {"day": "Tuesday", "high": 32, "wet": False},
+                {"day": "Sunday", "high": 27, "wet": True},
+            ],
+        },
+        "content": [
+            {"type": "text", "text": "# Briefing for ${location}\n\n"},
+            {
+                "type": "placeholder",
+                "instructionType": "summary",
+                "config": {
+                    "description": "Summarise the trends in the forecast reference data",
+                    "dataSource": "forecast",
+                },
+            },
+        ],
+    }
+
+
+def make_compiler() -> ITSCompiler:
+    security = SecurityConfig()
+    security.allowlist.interactive_mode = False
+    return ITSCompiler(security_config=security)
+
+
+class TestReferenceDataSections:
+    def test_renders_referenced_variables_above_the_template(self) -> None:
+        prompt = str(make_compiler().compile(forecast_template()).prompt)
+
+        assert "REFERENCE DATA" in prompt
+        assert "### forecast" in prompt
+        assert "| day | high | wet |" in prompt
+        assert "| Monday | 29 | false |" in prompt
+        assert REFERENCE_DATA_INSTRUCTION in prompt
+        assert prompt.index("REFERENCE DATA") < prompt.index("TEMPLATE")
+        template_section = prompt[prompt.index("TEMPLATE") :]
+        assert "| Monday |" not in template_section
+
+    def test_deduplicates_sources_across_placeholders(self) -> None:
+        template = forecast_template()
+        template["content"].append(
+            {
+                "type": "placeholder",
+                "instructionType": "summary",
+                "config": {
+                    "description": "Recommendations from the forecast reference data",
+                    "dataSource": ["forecast"],
+                },
+            }
+        )
+
+        prompt = str(make_compiler().compile(template).prompt)
+
+        assert prompt.count("### forecast") == 1
+
+    def test_omitted_when_no_placeholder_names_a_source(self) -> None:
+        template = forecast_template()
+        del template["content"][1]["config"]["dataSource"]
+
+        prompt = str(make_compiler().compile(template).prompt)
+
+        assert "REFERENCE DATA" not in prompt
+        assert REFERENCE_DATA_INSTRUCTION not in prompt
+
+    def test_unknown_source_fails_compilation(self) -> None:
+        template = forecast_template()
+        template["content"][1]["config"]["dataSource"] = "missing"
+
+        with pytest.raises(ITSCompilationError, match="Unknown data source 'missing'"):
+            make_compiler().compile(template)
+
+    def test_sources_in_excluded_branches_are_skipped(self) -> None:
+        template = forecast_template()
+        placeholder = template["content"][1]
+        template["variables"]["includeSummary"] = False
+        template["content"] = [
+            {"type": "text", "text": "Header\n"},
+            {"type": "conditional", "condition": "includeSummary == true", "content": [placeholder]},
+        ]
+
+        prompt = str(make_compiler().compile(template).prompt)
+
+        assert "REFERENCE DATA" not in prompt
+
+
+class TestRenderDataSource:
+    def test_primitive_array_renders_as_list(self) -> None:
+        assert render_data_source(["a", "b"]) == "- a\n- b"
+
+    def test_plain_object_renders_as_field_table(self) -> None:
+        assert render_data_source({"name": "x", "count": 2}) == (
+            "| Field | Value |\n| --- | --- |\n| name | x |\n| count | 2 |"
+        )
+
+    def test_nested_values_render_as_compact_json_with_escaped_pipes(self) -> None:
+        assert render_data_source([{"a": {"b": 1}, "note": "x|y"}]) == (
+            '| a | note |\n| --- | --- |\n| {"b":1} | x\\|y |'
+        )


### PR DESCRIPTION
Mirrors its-compiler-js PR #5: placeholders reference tabular data sources by variable name via the reserved dataSource config key; the compiler renders them once in a REFERENCE DATA section above the template (markdown tables for arrays of objects, field tables for plain objects, compact JSON for nested values, byte-compatible with the JS compiler) plus a context-only processing instruction. Dedupe, conditional-branch skipping and unknown-name errors match the JS behaviour. 304 tests passing; black, isort, flake8, mypy clean. Version 1.2.0 (supersedes untagged 1.1.0).