### PR TITLE
Data limits for reference data sources

### DIFF
--- a/its_compiler/core/compiler.py
+++ b/its_compiler/core/compiler.py
@@ -20,7 +20,7 @@ from .models import (
     TypeOverride,
     ValidationResult,
 )
-from .reference_data import REFERENCE_DATA_INSTRUCTION, collect_data_source_names, render_data_source
+from .reference_data import REFERENCE_DATA_INSTRUCTION, collect_data_sources, render_data_source
 from .schema_loader import SchemaLoader
 from .variable_processor import VariableProcessor
 
@@ -434,14 +434,14 @@ class ITSCompiler:
 
         # Reference data: variables named by placeholder dataSource configs are
         # rendered once above the template as context the model must not output
-        data_source_names = collect_data_source_names(content)
+        data_sources = collect_data_sources(content)
         reference_parts: List[str] = []
-        if data_source_names:
+        if data_sources:
             reference_parts.extend(["REFERENCE DATA", ""])
-            for name in data_source_names:
+            for name, limit in data_sources:
                 if name not in variables:
                     raise ITSCompilationError(f"Unknown data source '{name}': no variable with that name")
-                reference_parts.extend([f"### {name}", "", render_data_source(variables[name]), ""])
+                reference_parts.extend([f"### {name}", "", render_data_source(variables[name], limit), ""])
             processing_instructions.append(REFERENCE_DATA_INSTRUCTION)
 
         # Process content elements

--- a/its_compiler/core/reference_data.py
+++ b/its_compiler/core/reference_data.py
@@ -11,7 +11,7 @@ Rendering is kept byte-compatible with the JavaScript compiler.
 """
 
 import json
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional, Tuple
 
 REFERENCE_DATA_INSTRUCTION = (
     "Use the REFERENCE DATA section as context when generating placeholder content"
@@ -19,18 +19,39 @@ REFERENCE_DATA_INSTRUCTION = (
 )
 
 
-def collect_data_source_names(content: List[Dict[str, Any]]) -> List[str]:
-    """Collect data source names from placeholder configs, deduplicated in order of first appearance."""
-    names: List[str] = []
+def collect_data_sources(content: List[Dict[str, Any]]) -> List[Tuple[str, Optional[int]]]:
+    """Collect (name, limit) data source requests from placeholder configs.
+
+    Deduplicated in order of first appearance. A placeholder's optional
+    dataLimit config caps how much of each of its sources is included; when
+    several placeholders reference the same source the most generous request
+    wins (no limit beats any limit, otherwise the maximum).
+    """
+    requests: List[Tuple[str, Optional[int]]] = []
     for element in content:
         if element.get("type") != "placeholder":
             continue
-        raw = element.get("config", {}).get("dataSource")
+        config = element.get("config", {})
+        raw = config.get("dataSource")
+        raw_limit = config.get("dataLimit")
+        limit = raw_limit if isinstance(raw_limit, int) and not isinstance(raw_limit, bool) and raw_limit >= 1 else None
         candidates = [raw] if isinstance(raw, str) else raw if isinstance(raw, list) else []
         for candidate in candidates:
-            if isinstance(candidate, str) and candidate and candidate not in names:
-                names.append(candidate)
-    return names
+            if not isinstance(candidate, str) or not candidate:
+                continue
+            index = next((i for i, (name, _) in enumerate(requests) if name == candidate), None)
+            if index is None:
+                requests.append((candidate, limit))
+            else:
+                existing = requests[index][1]
+                if existing is not None:
+                    requests[index] = (candidate, None if limit is None else max(existing, limit))
+    return requests
+
+
+def collect_data_source_names(content: List[Dict[str, Any]]) -> List[str]:
+    """Collect data source names only. Kept for API compatibility."""
+    return [name for name, _ in collect_data_sources(content)]
 
 
 def _render_cell(value: Any) -> str:
@@ -54,15 +75,25 @@ def _render_object_table(rows: List[Dict[str, Any]]) -> str:
     return "\n".join(lines)
 
 
-def render_data_source(value: Any) -> str:
-    """Render one data source as markdown: arrays of objects become tables, plain objects become field tables."""
+def render_data_source(value: Any, limit: Optional[int] = None) -> str:
+    """Render one data source as markdown, capped at limit items or fields.
+
+    Arrays of objects become tables, plain objects become field tables, and
+    any truncation is stated so the model knows the data is partial.
+    Rendering is byte-compatible with the JavaScript compiler.
+    """
     if isinstance(value, list):
-        if value and all(isinstance(item, dict) for item in value):
-            return _render_object_table(value)
-        return "\n".join(f"- {_render_cell(item)}" for item in value)
+        items = value[:limit] if limit is not None and limit < len(value) else value
+        note = f"\n\nShowing the first {len(items)} of {len(value)} items." if len(items) < len(value) else ""
+        if items and all(isinstance(item, dict) for item in items):
+            return _render_object_table(items) + note
+        return "\n".join(f"- {_render_cell(item)}" for item in items) + note
     if isinstance(value, dict):
+        entries = list(value.items())
+        shown = entries[:limit] if limit is not None and limit < len(entries) else entries
+        note = f"\n\nShowing the first {len(shown)} of {len(entries)} fields." if len(shown) < len(entries) else ""
         lines = ["| Field | Value |", "| --- | --- |"]
-        for key, item in value.items():
+        for key, item in shown:
             lines.append(f"| {_render_cell(key)} | {_render_cell(item)} |")
-        return "\n".join(lines)
+        return "\n".join(lines) + note
     return _render_cell(value)

--- a/test/core/test_reference_data.py
+++ b/test/core/test_reference_data.py
@@ -105,6 +105,64 @@ class TestReferenceDataSections:
         assert "REFERENCE DATA" not in prompt
 
 
+class TestDataLimits:
+    def test_caps_items_at_the_placeholder_data_limit(self) -> None:
+        template = forecast_template()
+        template["content"][1]["config"]["dataLimit"] = 2
+
+        prompt = str(make_compiler().compile(template).prompt)
+
+        assert "| Monday | 29 | false |" in prompt
+        assert "| Tuesday | 32 | false |" in prompt
+        assert "| Sunday |" not in prompt
+        assert "Showing the first 2 of 3 items." in prompt
+
+    def test_maximum_limit_wins_across_placeholders(self) -> None:
+        template = forecast_template()
+        template["content"][1]["config"]["dataLimit"] = 1
+        template["content"].append(
+            {
+                "type": "placeholder",
+                "instructionType": "summary",
+                "config": {
+                    "description": "More from the forecast reference data",
+                    "dataSource": "forecast",
+                    "dataLimit": 2,
+                },
+            }
+        )
+
+        prompt = str(make_compiler().compile(template).prompt)
+
+        assert "Showing the first 2 of 3 items." in prompt
+        assert prompt.count("### forecast") == 1
+
+    def test_unlimited_reference_beats_any_limit(self) -> None:
+        template = forecast_template()
+        template["content"][1]["config"]["dataLimit"] = 1
+        template["content"].append(
+            {
+                "type": "placeholder",
+                "instructionType": "summary",
+                "config": {"description": "Everything from the forecast reference data", "dataSource": "forecast"},
+            }
+        )
+
+        prompt = str(make_compiler().compile(template).prompt)
+
+        assert "| Sunday | 27 | true |" in prompt
+        assert "Showing the first" not in prompt
+
+    def test_non_truncating_limit_adds_no_note(self) -> None:
+        template = forecast_template()
+        template["content"][1]["config"]["dataLimit"] = 50
+
+        prompt = str(make_compiler().compile(template).prompt)
+
+        assert "| Sunday | 27 | true |" in prompt
+        assert "Showing the first" not in prompt
+
+
 class TestRenderDataSource:
     def test_primitive_array_renders_as_list(self) -> None:
         assert render_data_source(["a", "b"]) == "- a\n- b"


### PR DESCRIPTION
Mirrors its-compiler-js PR #6: optional dataLimit placeholder config caps items or fields included from referenced data sources, with the truncation stated so the model knows the data is partial; the most generous request wins across placeholders sharing a source. 308 tests passing; black, isort, flake8, mypy clean.