### PR TITLE
Configurable variable payload limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,12 @@ compiler = ITSCompiler(config=config, security_config=security_config)
 
 - `ITS_MAX_TEMPLATE_SIZE` - Max template size in bytes (default: 1MB)
 - `ITS_MAX_CONTENT_ELEMENTS` - Max content elements (default: 1000)
+- `ITS_MAX_NESTING_DEPTH` - Max content/variable nesting depth (default: 10)
+- `ITS_MAX_VARIABLE_COUNT` - Max total variables including nested values (default: 10000)
+- `ITS_MAX_VARIABLE_ARRAY_ITEMS` - Max items per variable array (default: 1000)
+- `ITS_MAX_TEXT_LENGTH` - Max length of a text element or string value (default: 10000)
+
+All processing limits are also settable in code through `SecurityConfig().processing`, sized so reference data workloads (large datasets injected as variables) can be accommodated by the operator.
 
 **Feature Toggles:**
 

--- a/its_compiler/core/variable_processor.py
+++ b/its_compiler/core/variable_processor.py
@@ -27,7 +27,7 @@ class VariableProcessor:
 
         # Processing limits
         self.max_recursion_depth = self.security_config.processing.max_nesting_depth
-        self.max_variable_references = self.security_config.processing.max_variable_references
+        self.max_variable_count = self.security_config.processing.max_variable_count
         self.max_variable_name_length = self.security_config.processing.max_variable_name_length
 
     def process_content(self, content: List[Dict[str, Any]], variables: Dict[str, Any]) -> List[Dict[str, Any]]:
@@ -59,10 +59,10 @@ class VariableProcessor:
         if not isinstance(variables, dict):
             raise ITSVariableError("Variables must be a dictionary")
 
-        # Check total variable count
+        # Check total variable count (nested values included)
         total_vars = self._count_total_variables(variables)
-        if total_vars > self.max_variable_references:
-            raise ITSVariableError(f"Too many variables: {total_vars} (max: {self.max_variable_references})")
+        if total_vars > self.max_variable_count:
+            raise ITSVariableError(f"Too many variables: {total_vars} (max: {self.max_variable_count})")
 
         # Validate each variable recursively
         self._validate_variable_object(variables, "", 0)
@@ -97,7 +97,7 @@ class VariableProcessor:
                 self._validate_variable_object(value, f"{path}.{key}" if path else key, depth + 1)
 
         elif isinstance(obj, list):
-            if len(obj) > 1000:  # Reasonable limit for arrays
+            if len(obj) > self.security_config.processing.max_variable_array_items:
                 raise ITSVariableError(f"Array too large at {path}: {len(obj)} items")
 
             for i, item in enumerate(obj):
@@ -145,7 +145,7 @@ class VariableProcessor:
 
         if isinstance(value, str):
             # Check string length
-            if len(value) > 10000:  # Reasonable limit
+            if len(value) > self.security_config.processing.max_text_length:
                 raise ITSVariableError(f"String value too long at {path}: {len(value)} chars")
 
             # Check for dangerous content patterns
@@ -279,8 +279,9 @@ class VariableProcessor:
         else:
             # Convert other types to string with length limit
             str_value = str(value)
-            if len(str_value) > 1000:
-                str_value = str_value[:1000] + "... [TRUNCATED]"
+            max_text_length = self.security_config.processing.max_text_length
+            if len(str_value) > max_text_length:
+                str_value = str_value[:max_text_length] + "... [TRUNCATED]"
             return str_value
 
     def resolve_variable_reference(self, var_ref: str, variables: Dict[str, Any]) -> Any:
@@ -410,7 +411,7 @@ class VariableProcessor:
         """Get security status for variable processing."""
         return {
             "input_validation_enabled": self.input_validator is not None,
-            "max_variable_references": self.max_variable_references,
+            "max_variable_count": self.max_variable_count,
             "max_variable_name_length": self.max_variable_name_length,
             "max_recursion_depth": self.max_recursion_depth,
         }

--- a/its_compiler/security/config.py
+++ b/its_compiler/security/config.py
@@ -63,6 +63,12 @@ class ProcessingSecurityConfig:
     max_array_index: int = 1000
     allowed_variable_chars: str = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_"
 
+    # Variable payload limits, sized for reference data workloads and
+    # configurable for larger datasets
+    max_variable_count: int = 10000
+    max_variable_array_items: int = 1000
+    max_text_length: int = 10000
+
     # Conditional expressions
     max_expression_length: int = 500
     max_expression_depth: int = 10
@@ -178,6 +184,15 @@ class SecurityConfig:
 
         if max_depth := os.getenv("ITS_MAX_NESTING_DEPTH"):
             config.processing.max_nesting_depth = int(max_depth)
+
+        if max_variable_count := os.getenv("ITS_MAX_VARIABLE_COUNT"):
+            config.processing.max_variable_count = int(max_variable_count)
+
+        if max_array_items := os.getenv("ITS_MAX_VARIABLE_ARRAY_ITEMS"):
+            config.processing.max_variable_array_items = int(max_array_items)
+
+        if max_text_length := os.getenv("ITS_MAX_TEXT_LENGTH"):
+            config.processing.max_text_length = int(max_text_length)
 
         # Feature toggles
         if os.getenv("ITS_ALLOW_LOCAL_SCHEMAS") == "true":

--- a/its_compiler/security/input_validator.py
+++ b/its_compiler/security/input_validator.py
@@ -337,7 +337,7 @@ class InputValidator:
                 self._validate_variable_name(k)
                 self._validate_variable_value(v, f"{path}.{k}")
         elif isinstance(value, list):
-            if len(value) > 1000:  # Reasonable limit
+            if len(value) > self.processing_config.max_variable_array_items:
                 self._security_violation(
                     f"Array too large in variable {path}",
                     "variable_value",
@@ -438,7 +438,7 @@ class InputValidator:
         """Validate text content for malicious patterns."""
 
         # Length check
-        if len(text) > 10000:
+        if len(text) > self.processing_config.max_text_length:
             self._security_violation(f"Text content too long in {context}", "text_content", "text_too_long")
 
         # Check for null bytes (security bypass attack)

--- a/test/core/test_configurable_limits.py
+++ b/test/core/test_configurable_limits.py
@@ -1,0 +1,60 @@
+"""Tests for configurable variable payload limits."""
+
+from typing import Any, Dict
+
+import pytest
+
+from its_compiler import ITSCompiler
+from its_compiler.core.exceptions import ITSValidationError, ITSVariableError
+from its_compiler.security import SecurityConfig
+
+
+def dataset_template(rows: int) -> Dict[str, Any]:
+    return {
+        "version": "1.0.0",
+        "customInstructionTypes": {"summary": {"template": "<<Summarise using this prompt: ([{<{description}>}]).>>"}},
+        "variables": {"rows": [{"n": i} for i in range(rows)]},
+        "content": [
+            {
+                "type": "placeholder",
+                "instructionType": "summary",
+                "config": {"description": "Summarise the rows reference data", "dataSource": "rows", "dataLimit": 5},
+            }
+        ],
+    }
+
+
+def compiler_with(**processing_overrides: int) -> ITSCompiler:
+    security = SecurityConfig()
+    security.allowlist.interactive_mode = False
+    for name, value in processing_overrides.items():
+        setattr(security.processing, name, value)
+    return ITSCompiler(security_config=security)
+
+
+class TestConfigurableLimits:
+    def test_default_variable_count_accepts_reference_datasets(self) -> None:
+        # 500 rows was rejected by the old hardcoded conflated cap of 100
+        result = compiler_with().compile(dataset_template(500))
+        assert "Showing the first 5 of 500 items." in str(result.prompt)
+
+    def test_variable_count_is_configurable(self) -> None:
+        with pytest.raises(ITSVariableError, match="Too many variables"):
+            compiler_with(max_variable_count=50).compile(dataset_template(60))
+
+    def test_array_items_limit_is_configurable(self) -> None:
+        # Surfaces via the input validator or the variable processor depending
+        # on which security layer is enabled; both honour the configured cap
+        with pytest.raises((ITSValidationError, ITSVariableError), match="Array too large"):
+            compiler_with(max_variable_array_items=10).compile(dataset_template(11))
+
+    def test_environment_overrides_map_to_processing_limits(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ITS_MAX_VARIABLE_COUNT", "123")
+        monkeypatch.setenv("ITS_MAX_VARIABLE_ARRAY_ITEMS", "45")
+        monkeypatch.setenv("ITS_MAX_TEXT_LENGTH", "67")
+
+        config = SecurityConfig.from_environment()
+
+        assert config.processing.max_variable_count == 123
+        assert config.processing.max_variable_array_items == 45
+        assert config.processing.max_text_length == 67

--- a/test/core/test_variable_resolution.py
+++ b/test/core/test_variable_resolution.py
@@ -1,4 +1,4 @@
-"""
+﻿"""
 Tests for variable resolution and processing edge cases.
 Tests complex variable scenarios, error conditions, and security validation.
 """
@@ -240,11 +240,11 @@ class TestVariableResolution:
         status = processor.get_security_status()
 
         assert "input_validation_enabled" in status
-        assert "max_variable_references" in status
+        assert "max_variable_count" in status
         assert "max_variable_name_length" in status
         assert "max_recursion_depth" in status
 
-        assert isinstance(status["max_variable_references"], int)
+        assert isinstance(status["max_variable_count"], int)
         assert isinstance(status["max_variable_name_length"], int)
 
     def test_variable_name_security_validation(self, processor: VariableProcessor) -> None:


### PR DESCRIPTION
The total-variable cap reused max_variable_references (100) and counted nested items, so a 100-row dataset was rejected before dataLimit could apply. Adds dedicated, configurable limits: max_variable_count (default 10000), max_variable_array_items (default 1000) and max_text_length (default 10000), replacing hardcoded values in the input validator and variable processor, with ITS_MAX_VARIABLE_COUNT / ITS_MAX_VARIABLE_ARRAY_ITEMS / ITS_MAX_TEXT_LENGTH env mappings and README docs. 313 tests passing; black, isort, flake8, mypy clean.