### PR TITLE
Object references render as reference data

### DIFF
--- a/its_compiler/core/compiler.py
+++ b/its_compiler/core/compiler.py
@@ -127,14 +127,16 @@ class ITSCompiler:
         # Load and resolve instruction types
         instruction_types, overrides = self._load_instruction_types(template, base_url)
 
-        # Process variables in content with security
-        processed_content = self._process_variables(template["content"], merged_variables)
+        # Process variables in content with security; object-valued references
+        # are collected and rendered as reference data
+        object_references: Dict[str, Any] = {}
+        processed_content = self._process_variables(template["content"], merged_variables, object_references)
 
         # Evaluate conditionals with security
         final_content = self._evaluate_conditionals(processed_content, merged_variables)
 
         # Generate final prompt
-        prompt = self._generate_prompt(final_content, instruction_types, template, merged_variables)
+        prompt = self._generate_prompt(final_content, instruction_types, template, merged_variables, object_references)
 
         # Validate final prompt
         self._validate_final_prompt(prompt)
@@ -405,9 +407,14 @@ class ITSCompiler:
 
         return instruction_types, overrides
 
-    def _process_variables(self, content: List[Dict[str, Any]], variables: Dict[str, Any]) -> List[Dict[str, Any]]:
+    def _process_variables(
+        self,
+        content: List[Dict[str, Any]],
+        variables: Dict[str, Any],
+        object_references: Optional[Dict[str, Any]] = None,
+    ) -> List[Dict[str, Any]]:
         """Process variable references in content with security."""
-        return self.variable_processor.process_content(content, variables)
+        return self.variable_processor.process_content(content, variables, object_references)
 
     def _evaluate_conditionals(self, content: List[Dict[str, Any]], variables: Dict[str, Any]) -> List[Dict[str, Any]]:
         """Evaluate conditional elements with security."""
@@ -419,9 +426,11 @@ class ITSCompiler:
         instruction_types: Dict[str, InstructionTypeDefinition],
         template: Dict[str, Any],
         variables: Optional[Dict[str, Any]] = None,
+        object_references: Optional[Dict[str, Any]] = None,
     ) -> str:
         """Generate the final AI prompt."""
         variables = variables or {}
+        object_references = object_references or {}
 
         # Get compiler configuration
         compiler_config = template.get("compilerConfig", {})
@@ -435,13 +444,20 @@ class ITSCompiler:
         # Reference data: variables named by placeholder dataSource configs are
         # rendered once above the template as context the model must not output
         data_sources = collect_data_sources(content)
+        for name in object_references:
+            if all(existing != name for existing, _ in data_sources):
+                data_sources.append((name, None))
         reference_parts: List[str] = []
         if data_sources:
             reference_parts.extend(["REFERENCE DATA", ""])
             for name, limit in data_sources:
-                if name not in variables:
+                if name in variables:
+                    value = variables[name]
+                elif name in object_references:
+                    value = object_references[name]
+                else:
                     raise ITSCompilationError(f"Unknown data source '{name}': no variable with that name")
-                reference_parts.extend([f"### {name}", "", render_data_source(variables[name], limit), ""])
+                reference_parts.extend([f"### {name}", "", render_data_source(value, limit), ""])
             processing_instructions.append(REFERENCE_DATA_INSTRUCTION)
 
         # Process content elements

--- a/its_compiler/core/variable_processor.py
+++ b/its_compiler/core/variable_processor.py
@@ -1,4 +1,4 @@
-"""
+﻿"""
 Variable processing for ITS Compiler with security enhancements.
 Variables can only contain static values - no references to other variables.
 """
@@ -30,7 +30,12 @@ class VariableProcessor:
         self.max_variable_count = self.security_config.processing.max_variable_count
         self.max_variable_name_length = self.security_config.processing.max_variable_name_length
 
-    def process_content(self, content: List[Dict[str, Any]], variables: Dict[str, Any]) -> List[Dict[str, Any]]:
+    def process_content(
+        self,
+        content: List[Dict[str, Any]],
+        variables: Dict[str, Any],
+        object_references: Optional[Dict[str, Any]] = None,
+    ) -> List[Dict[str, Any]]:
         """Process variable references in content elements with security validation."""
 
         # Validate variables first
@@ -44,7 +49,7 @@ class VariableProcessor:
 
         for element in content:
             try:
-                processed_element = self._process_element(element, variables)
+                processed_element = self._process_element(element, variables, object_references)
                 processed_content.append(processed_element)
             except ITSVariableError:
                 raise
@@ -168,63 +173,83 @@ class VariableProcessor:
             if isinstance(value, (int, float)) and abs(value) > 1e15:
                 raise ITSVariableError(f"Numeric value too large at {path}: {value}")
 
-    def _process_element(self, element: Dict[str, Any], variables: Dict[str, Any]) -> Dict[str, Any]:
+    def _process_element(
+        self,
+        element: Dict[str, Any],
+        variables: Dict[str, Any],
+        object_references: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
         """Process variables in a single content element."""
         element_copy = element.copy()
 
         if element["type"] == "text":
             # Process variables in text content
-            element_copy["text"] = self._process_string(element["text"], variables)
+            element_copy["text"] = self._process_string(element["text"], variables, object_references)
 
         elif element["type"] == "placeholder":
             # Process variables in placeholder config
-            element_copy["config"] = self._process_dict(element["config"], variables)
+            element_copy["config"] = self._process_dict(element["config"], variables, object_references)
 
         elif element["type"] == "conditional":
-            # Process variables in condition expression
+            # Process variables in condition expression (no object pointers there)
             element_copy["condition"] = self._process_string(element["condition"], variables)
 
             # Recursively process nested content
-            element_copy["content"] = self.process_content(element["content"], variables)
+            element_copy["content"] = self.process_content(element["content"], variables, object_references)
 
             if "else" in element:
-                element_copy["else"] = self.process_content(element["else"], variables)
+                element_copy["else"] = self.process_content(element["else"], variables, object_references)
 
         return element_copy
 
-    def _process_dict(self, data: Dict[str, Any], variables: Dict[str, Any]) -> Dict[str, Any]:
+    def _process_dict(
+        self,
+        data: Dict[str, Any],
+        variables: Dict[str, Any],
+        object_references: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
         """Process variables in a dictionary."""
         processed: Dict[str, Any] = {}
 
         for key, value in data.items():
             if isinstance(value, str):
-                processed[key] = self._process_string(value, variables)
+                processed[key] = self._process_string(value, variables, object_references)
             elif isinstance(value, dict):
-                processed[key] = self._process_dict(value, variables)
+                processed[key] = self._process_dict(value, variables, object_references)
             elif isinstance(value, list):
-                processed[key] = self._process_list(value, variables)
+                processed[key] = self._process_list(value, variables, object_references)
             else:
                 processed[key] = value
 
         return processed
 
-    def _process_list(self, data: List[Any], variables: Dict[str, Any]) -> List[Any]:
+    def _process_list(
+        self,
+        data: List[Any],
+        variables: Dict[str, Any],
+        object_references: Optional[Dict[str, Any]] = None,
+    ) -> List[Any]:
         """Process variables in a list."""
         processed: List[Any] = []
 
         for item in data:
             if isinstance(item, str):
-                processed.append(self._process_string(item, variables))
+                processed.append(self._process_string(item, variables, object_references))
             elif isinstance(item, dict):
-                processed.append(self._process_dict(item, variables))
+                processed.append(self._process_dict(item, variables, object_references))
             elif isinstance(item, list):
-                processed.append(self._process_list(item, variables))
+                processed.append(self._process_list(item, variables, object_references))
             else:
                 processed.append(item)
 
         return processed
 
-    def _process_string(self, text: str, variables: Dict[str, Any]) -> str:
+    def _process_string(
+        self,
+        text: str,
+        variables: Dict[str, Any],
+        object_references: Optional[Dict[str, Any]] = None,
+    ) -> str:
         """Process variable references in a string with security validation."""
 
         # Check for too many variable references in a single string
@@ -245,6 +270,11 @@ class VariableProcessor:
 
             try:
                 value = self.resolve_variable_reference(var_ref, variables)
+
+                # Object values substitute a pointer and render as reference data
+                if object_references is not None and isinstance(value, dict):
+                    object_references[var_ref] = value
+                    return f"the {var_ref} reference data"
 
                 # Sanitise the resolved value
                 sanitised_value = self._sanitise_resolved_value(value, var_ref)

--- a/test/core/test_object_reference_data.py
+++ b/test/core/test_object_reference_data.py
@@ -1,0 +1,74 @@
+"""Tests for object references substituting a pointer and rendering as reference data."""
+
+from typing import Any, Dict
+
+from its_compiler import ITSCompiler
+from its_compiler.core.reference_data import REFERENCE_DATA_INSTRUCTION
+from its_compiler.security import SecurityConfig
+
+
+def template(text: str) -> Dict[str, Any]:
+    return {
+        "version": "1.0.0",
+        "variables": {
+            "school": {"name": "Riverbank Secondary", "students": 940},
+            "product": {"details": {"weight": "1.2kg", "battery": "12h"}},
+        },
+        "content": [{"type": "text", "text": text}],
+    }
+
+
+def compile_prompt(text: str, extra_content: Any = None) -> str:
+    data = template(text)
+    if extra_content:
+        data.update(extra_content)
+    security = SecurityConfig()
+    security.allowlist.interactive_mode = False
+    return str(ITSCompiler(security_config=security).compile(data).prompt)
+
+
+class TestObjectReferenceData:
+    def test_pointer_substitution_and_field_table(self) -> None:
+        prompt = compile_prompt("Prepared for ${school}.")
+
+        assert "Prepared for the school reference data." in prompt
+        assert "[Object with" not in prompt
+        assert "### school" in prompt
+        assert "| name | Riverbank Secondary |" in prompt
+        assert "| students | 940 |" in prompt
+        assert REFERENCE_DATA_INSTRUCTION in prompt
+
+    def test_nested_object_path_names_the_section(self) -> None:
+        prompt = compile_prompt("Specs: ${product.details}.")
+
+        assert "Specs: the product.details reference data." in prompt
+        assert "### product.details" in prompt
+        assert "| weight | 1.2kg |" in prompt
+
+    def test_deduplicates_with_explicit_data_source(self) -> None:
+        prompt = compile_prompt(
+            "About ${school}.",
+            {
+                "customInstructionTypes": {"summary": {"template": "<<Summarise: ([{<{description}>}]).>>"}},
+            },
+        )
+        data = template("About ${school}.")
+        data["customInstructionTypes"] = {"summary": {"template": "<<Summarise: ([{<{description}>}]).>>"}}
+        data["content"].append(
+            {
+                "type": "placeholder",
+                "instructionType": "summary",
+                "config": {"description": "Summarise the school reference data", "dataSource": "school"},
+            }
+        )
+        security = SecurityConfig()
+        security.allowlist.interactive_mode = False
+        prompt = str(ITSCompiler(security_config=security).compile(data).prompt)
+
+        assert prompt.count("### school") == 1
+
+    def test_scalars_and_arrays_unchanged(self) -> None:
+        prompt = compile_prompt("Name: ${school.name}, students: ${school.students}.")
+
+        assert "Name: Riverbank Secondary, students: 940." in prompt
+        assert "REFERENCE DATA" not in prompt


### PR DESCRIPTION
Mirrors its-compiler-js PR: object-valued references substitute a textual pointer and the object renders automatically in the REFERENCE DATA section (field table, path-named section, deduplicated with explicit dataSource requests). 322 tests passing; linters clean.