### PR TITLE
Preserve specific variable errors plus test audit hardening

### DIFF
--- a/its_compiler/core/variable_processor.py
+++ b/its_compiler/core/variable_processor.py
@@ -281,8 +281,10 @@ class VariableProcessor:
 
                 return sanitised_value
 
-            except ITSVariableError:
-                # Re-raise with more context
+            except ITSVariableError as e:
+                # Errors that already name their cause pass through unchanged
+                if e.variable_path:
+                    raise
                 raise ITSVariableError(
                     f"Undefined variable reference: ${{{var_ref}}}",
                     variable_path=var_ref,

--- a/test/core/test_collection_functions.py
+++ b/test/core/test_collection_functions.py
@@ -38,11 +38,11 @@ class TestCollectionFunctions:
         assert "solar, garden, lantern" in compile_text("${tags.concat()}")
 
     def test_aggregations(self) -> None:
-        assert "82" in compile_text("${forecast.sum(high)}")
-        assert "15" in compile_text("${scores.sum()}")
-        assert "5" in compile_text("${scores.avg()}")
-        assert "24" in compile_text("${forecast.min(high)}")
-        assert "31" in compile_text("${forecast.max(high)}")
+        assert "sum=82." in compile_text("sum=${forecast.sum(high)}.")
+        assert "sum=15." in compile_text("sum=${scores.sum()}.")
+        assert "avg=5." in compile_text("avg=${scores.avg()}.")
+        assert "min=24." in compile_text("min=${forecast.min(high)}.")
+        assert "max=31." in compile_text("max=${forecast.max(high)}.")
 
     def test_top_slices_and_chains(self) -> None:
         assert "Monday, Tuesday" in compile_text("${forecast.top(2).concat(day)}")
@@ -51,12 +51,16 @@ class TestCollectionFunctions:
     def test_booleans_concat_json_style(self) -> None:
         assert "false, true, false" in compile_text("${forecast.concat(wet)}")
 
-    def test_invalid_usages_fail(self) -> None:
-        for reference in [
-            "${forecast[0].sum(high)}",
-            "${forecast.sum(missing)}",
-            "${forecast.sum(day)}",
-            "${forecast.top(x)}",
-        ]:
-            with pytest.raises((ITSVariableError, Exception)):
-                compile_text(reference)
+    @pytest.mark.parametrize(
+        "reference,expected",
+        [
+            ("${forecast[0].sum(high)}", r"sum\(\) requires an array"),
+            ("${forecast.sum(missing)}", r"Property 'missing' not found on every item"),
+            ("${forecast.sum(day)}", r"sum\(\) requires numeric values"),
+            ("${forecast.top(x)}", r"top\(\) requires a non-negative integer"),
+            ("${forecast.concat(day).sum()}", r"sum\(\) requires an array"),
+        ],
+    )
+    def test_invalid_usages_fail(self, reference: str, expected: str) -> None:
+        with pytest.raises(ITSVariableError, match=expected):
+            compile_text(reference)

--- a/test/core/test_compiler_edge_cases.py
+++ b/test/core/test_compiler_edge_cases.py
@@ -14,7 +14,7 @@ from urllib.error import HTTPError, URLError
 import pytest
 
 from its_compiler import ITSCompiler, ITSConfig
-from its_compiler.core.exceptions import ITSCompilationError, ITSValidationError, ITSVariableError
+from its_compiler.core.exceptions import ITSCompilationError, ITSValidationError
 from its_compiler.security import SecurityConfig
 
 
@@ -192,13 +192,8 @@ class TestCompilerEdgeCases:
         # Create variables for all levels
         variables = {f"level{i}": True for i in range(10)}
 
-        # Should either process successfully or hit nesting limits
-        try:
-            result = compiler.compile(template, variables)
-            assert "deeply nested" in result.prompt
-        except (ITSValidationError, ITSCompilationError):
-            # Acceptable if nesting limits are hit
-            pass
+        result = compiler.compile(template, variables)
+        assert "deeply nested" in result.prompt
 
     def test_large_variable_object_processing(self, compiler: ITSCompiler) -> None:
         """Test processing of large variable objects."""
@@ -212,14 +207,8 @@ class TestCompilerEdgeCases:
             "content": [{"type": "text", "text": "Processing ${var0.name} and ${var99.name}"}],
         }
 
-        # Should either process successfully or hit variable limits
-        try:
-            result = compiler.compile(template, large_vars)
-            assert "item0" in result.prompt
-            assert "item99" in result.prompt
-        except (ITSValidationError, ITSCompilationError, ITSVariableError):
-            # Acceptable if variable limits are hit
-            pass
+        result = compiler.compile(template, large_vars)
+        assert "Processing item0 and item99" in result.prompt
 
     def test_extreme_edge_case_file_operations(self, compiler: ITSCompiler, temp_directory: Path) -> None:
         """Test extreme edge cases in file operations."""
@@ -251,13 +240,9 @@ class TestCompilerEdgeCases:
 
         template = {"version": "1.0.0", "content": large_elements}
 
-        # Should either process or hit memory/size limits
-        try:
-            result = compiler.compile(template)
-            assert len(result.prompt) > 100000  # Should be substantial
-        except (ITSValidationError, ITSCompilationError):
-            # Acceptable if size limits are hit
-            pass
+        result = compiler.compile(template)
+        assert len(result.prompt) > 100000
+        assert result.prompt.count("x" * 1000) == 100
 
     def test_schema_loading_with_comprehensive_error_scenarios(
         self, compiler: ITSCompiler, temp_directory: Path

--- a/test/core/test_variable_resolution.py
+++ b/test/core/test_variable_resolution.py
@@ -256,16 +256,11 @@ class TestVariableResolution:
             "__proto__": "dangerous",
         }
 
-        content: List[Dict[str, Any]] = [{"type": "text", "text": "Test ${dangerous_var}"}]
+        content: List[Dict[str, Any]] = [{"type": "text", "text": "static text only"}]
 
         for var_name, value in dangerous_variables.items():
-            variables_with_dangerous = {var_name: value}
-            # Should either block or handle safely
-            try:
-                processor.process_content(content, variables_with_dangerous)
-            except ITSVariableError:
-                # Blocking dangerous variables is acceptable
-                pass
+            with pytest.raises(ITSVariableError, match="[Dd]angerous"):
+                processor.process_content(content, {var_name: value})
 
     def test_extremely_deep_nesting_security(self, strict_processor: VariableProcessor) -> None:
         """Test security limits on extremely deep object nesting."""
@@ -282,7 +277,7 @@ class TestVariableResolution:
         # Extremely deep reference should be blocked
         very_deep_ref = "deep." + ".".join(f"level{i}" for i in range(30)) + ".value"
 
-        with pytest.raises(ITSVariableError):
+        with pytest.raises(ITSVariableError, match="too deep|too long"):
             strict_processor.resolve_variable_reference(very_deep_ref, variables)
 
     def test_large_array_index_security(self, strict_processor: VariableProcessor) -> None:
@@ -290,7 +285,7 @@ class TestVariableResolution:
         variables = {"large_array": list(range(1000))}
 
         # Extremely large index should be blocked
-        with pytest.raises(ITSVariableError):
+        with pytest.raises(ITSVariableError, match="index too large|out of bounds"):
             strict_processor.resolve_variable_reference("large_array[999999]", variables)
 
     def test_variable_processing_performance_limits(self, strict_processor: VariableProcessor) -> None:
@@ -301,9 +296,9 @@ class TestVariableResolution:
         # Create matching variables
         many_variables = {f"var{i}": f"value{i}" for i in range(200)}
 
-        # Should handle reasonable amounts but enforce limits
-        try:
-            strict_processor.process_content(large_content, many_variables)
-        except ITSVariableError:
-            # Performance limits may trigger - this is acceptable
-            pass
+        # A reasonable volume must process fully, with every reference resolved
+        processed = strict_processor.process_content(large_content, many_variables)
+
+        assert len(processed) == 200
+        assert processed[0]["text"] == "Var 0: value0"
+        assert processed[199]["text"] == "Var 199: value199"


### PR DESCRIPTION
Test audit outcome. Fix: specific resolution errors (bounds, collection-function misuse) are no longer masked as 'Undefined variable reference' - they pass through with their real message, matching JS and dotnet. Weak tests (assert-nothing try/except, catch-all raises) replaced with deterministic message-matched assertions. 326 tests passing, linters clean.