### PR TITLE
Markdown type library coverage and HTML 1.1.0 fixtures

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,10 +158,11 @@ Templates import instruction types through `extends`. The specification publishe
 | -------------- | ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
 | Standard Types | `its-standard-types-v1.json` | Prose content: titles, lists, paragraphs, tables, dialogue and more                                                                    |
 | JSON Types     | `its-json-types-v1.json`     | Value fills inside JSON structure authored in the template: json_string, json_number, json_value, json_array_items, json_object_fields |
-| HTML Types     | `its-html-types-v1.json`     | Fills inside literal markup: html_text, html_fragment, html_list_items, html_table_rows, html_form_fields                              |
+| HTML Types     | `its-html-types-v1.json`     | 5 position fills (html_text, html_fragment, html_list_items, html_table_rows, html_form_fields) plus 10 complete-element generators (html_heading, html_paragraph, html_link, html_image, html_list, html_table, html_section, html_blockquote, html_code_block, html_form) |
 | YAML Types     | `its-yaml-types-v1.json`     | Fills inside literal YAML: yaml_value, yaml_list_items, yaml_block                                                                     |
+| Markdown Types | `its-markdown-types-v1.json` | Fills inside literal Markdown: markdown_text, markdown_block, markdown_list_items, markdown_table_rows, markdown_code                  |
 
-The structured-output libraries (JSON, HTML, YAML) instruct the model to emit raw output with no markdown code fences and no commentary. If a placeholder omits a config property, defaults declared in the library's `configSchema` are substituted into the compiled instruction.
+The structured-output libraries (JSON, HTML, YAML, Markdown) instruct the model to emit raw output with no code fences and no commentary. If a placeholder omits a config property, defaults declared in the library's `configSchema` are substituted into the compiled instruction.
 
 `extends` entries may also be local file paths relative to the template, useful when developing unpublished type libraries. This is disabled by default; enable it with `SecurityConfig.allow_local_schemas()` or `ITS_ALLOW_LOCAL_SCHEMAS=true`.
 

--- a/test/fixtures/type_libraries/its-html-types-v1.json
+++ b/test/fixtures/type_libraries/its-html-types-v1.json
@@ -2,8 +2,8 @@
   "$schema": "https://alexanderparker.github.io/instruction-template-specification/schema/v1.0/its-type-extension-schema-v1.json",
   "$id": "https://alexanderparker.github.io/instruction-template-specification/schema/v1.0/its-html-types-v1.json",
   "title": "Instruction Template Specification - HTML Types v1.0",
-  "description": "Type library for filling positions inside HTML markup authored in the template; the template text carries the surrounding tags and attributes verbatim, never full documents",
-  "version": "1.0.0",
+  "description": "Type library for filling positions inside HTML markup authored in the template and for generating complete common elements; the template text carries the surrounding tags and attributes verbatim, never full documents",
+  "version": "1.1.0",
   "instructionTypes": {
     "html_text": {
       "template": "<<Replace this placeholder with HTML text content using this user prompt: ([{<{description}>}]). Format requirements: Produce text content for the enclosing element without repeating or closing its tags, escaping HTML special characters in the text. Inline markup such as strong, em and a is allowed: {allowInlineMarkup}. Output raw, valid HTML only - no markdown code fences, no surrounding commentary, and no explanation.>>",
@@ -79,6 +79,154 @@
     "html_form_fields": {
       "template": "<<Replace this placeholder with HTML form fields using this user prompt: ([{<{description}>}]). Format requirements: Produce form field controls valid at this position inside the enclosing form or container, without producing a form element. Include a label element for each control: {includeLabels}. Output raw, valid HTML only - no markdown code fences, no surrounding commentary, and no explanation.>>",
       "description": "Generates labelled form controls for a position inside a form or container authored in the template",
+      "configSchema": {
+        "type": "object",
+        "properties": {
+          "fieldCount": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 15,
+            "description": "If specified, the exact number of form fields to generate"
+          },
+          "includeLabels": {
+            "type": "boolean",
+            "default": true
+          }
+        }
+      }
+    },
+    "html_heading": {
+      "template": "<<Replace this placeholder with an HTML heading using this user prompt: ([{<{description}>}]). Format requirements: Produce a complete h{level} element including its opening and closing tags, with text content only. Output raw, valid HTML only - no markdown code fences, no surrounding commentary, and no explanation.>>",
+      "description": "Generates a complete heading element at a stated level",
+      "configSchema": {
+        "type": "object",
+        "properties": {
+          "level": {
+            "type": "integer",
+            "enum": [
+              1,
+              2,
+              3,
+              4,
+              5,
+              6
+            ],
+            "default": 2
+          }
+        }
+      }
+    },
+    "html_paragraph": {
+      "template": "<<Replace this placeholder with an HTML paragraph using this user prompt: ([{<{description}>}]). Format requirements: Produce a complete p element including its opening and closing tags, escaping HTML special characters in the text. Output raw, valid HTML only - no markdown code fences, no surrounding commentary, and no explanation.>>",
+      "description": "Generates a complete paragraph element"
+    },
+    "html_link": {
+      "template": "<<Replace this placeholder with an HTML link using this user prompt: ([{<{description}>}]). Format requirements: Produce a complete a element with an href attribute and link text. Use https://www.example.com for illustrative URLs unless the prompt supplies one. Output raw, valid HTML only - no markdown code fences, no surrounding commentary, and no explanation.>>",
+      "description": "Generates a complete anchor element with an href and link text"
+    },
+    "html_image": {
+      "template": "<<Replace this placeholder with an HTML image using this user prompt: ([{<{description}>}]). Format requirements: Produce a complete img element with a src attribute and descriptive alt text. Use example.com for illustrative URLs unless the prompt supplies one. Wrap the image in a figure element with a figcaption: {includeCaption}. Output raw, valid HTML only - no markdown code fences, no surrounding commentary, and no explanation.>>",
+      "description": "Generates a complete image element with a source and descriptive alternative text",
+      "configSchema": {
+        "type": "object",
+        "properties": {
+          "includeCaption": {
+            "type": "boolean",
+            "default": false
+          }
+        }
+      }
+    },
+    "html_list": {
+      "template": "<<Replace this placeholder with an HTML list using this user prompt: ([{<{description}>}]). Format requirements: Produce a complete {listType} list element including its items (a ul element for unordered, an ol element for ordered, a dl element with dt and dd pairs for description). Output raw, valid HTML only - no markdown code fences, no surrounding commentary, and no explanation.>>",
+      "description": "Generates a complete list element including its items",
+      "configSchema": {
+        "type": "object",
+        "properties": {
+          "listType": {
+            "type": "string",
+            "enum": [
+              "unordered",
+              "ordered",
+              "description"
+            ],
+            "default": "unordered"
+          },
+          "itemCount": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 20,
+            "description": "If specified, the exact number of items to generate"
+          }
+        }
+      }
+    },
+    "html_table": {
+      "template": "<<Replace this placeholder with an HTML table using this user prompt: ([{<{description}>}]). Format requirements: Produce a complete table element containing tr rows of td cells inside a tbody. Include a thead with header cells: {includeHeader}. Output raw, valid HTML only - no markdown code fences, no surrounding commentary, and no explanation.>>",
+      "description": "Generates a complete table element including its rows",
+      "configSchema": {
+        "type": "object",
+        "properties": {
+          "rows": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 50,
+            "description": "If specified, the exact number of rows to generate"
+          },
+          "columns": {
+            "type": "integer",
+            "minimum": 2,
+            "maximum": 10,
+            "description": "If specified, the number of cells per row"
+          },
+          "includeHeader": {
+            "type": "boolean",
+            "default": true
+          }
+        }
+      }
+    },
+    "html_section": {
+      "template": "<<Replace this placeholder with an HTML section using this user prompt: ([{<{description}>}]). Format requirements: Produce a complete section element opening with an h{headingLevel} heading followed by content elements matching the prompt. Output raw, valid HTML only - no markdown code fences, no surrounding commentary, and no explanation.>>",
+      "description": "Generates a complete section element opening with a heading",
+      "configSchema": {
+        "type": "object",
+        "properties": {
+          "headingLevel": {
+            "type": "integer",
+            "enum": [
+              1,
+              2,
+              3,
+              4,
+              5,
+              6
+            ],
+            "default": 2
+          }
+        }
+      }
+    },
+    "html_blockquote": {
+      "template": "<<Replace this placeholder with an HTML block quote using this user prompt: ([{<{description}>}]). Format requirements: Produce a complete blockquote element including its opening and closing tags. Output raw, valid HTML only - no markdown code fences, no surrounding commentary, and no explanation.>>",
+      "description": "Generates a complete blockquote element"
+    },
+    "html_code_block": {
+      "template": "<<Replace this placeholder with an HTML code block using this user prompt: ([{<{description}>}]). Format requirements: Produce a complete pre element containing a code element, escaping HTML special characters in the code. When the prompt states a language, mark it with a class attribute in the form language-... on the code element. Output raw, valid HTML only - no markdown code fences, no surrounding commentary, and no explanation.>>",
+      "description": "Generates a complete pre element containing a code element",
+      "configSchema": {
+        "type": "object",
+        "properties": {
+          "language": {
+            "type": "string",
+            "description": "If specified, the programming language for the code element's language-... class"
+          }
+        }
+      }
+    },
+    "html_form": {
+      "template": "<<Replace this placeholder with an HTML form using this user prompt: ([{<{description}>}]). Format requirements: Produce a complete form element containing form field controls and a submit button. Include a label element for each control: {includeLabels}. Output raw, valid HTML only - no markdown code fences, no surrounding commentary, and no explanation.>>",
+      "description": "Generates a complete form element with labelled controls and a submit button",
       "configSchema": {
         "type": "object",
         "properties": {

--- a/test/fixtures/type_libraries/its-markdown-types-v1.json
+++ b/test/fixtures/type_libraries/its-markdown-types-v1.json
@@ -1,0 +1,103 @@
+{
+  "$schema": "https://alexanderparker.github.io/instruction-template-specification/schema/v1.0/its-type-extension-schema-v1.json",
+  "$id": "https://alexanderparker.github.io/instruction-template-specification/schema/v1.0/its-markdown-types-v1.json",
+  "title": "Instruction Template Specification - Markdown Types v1.0",
+  "description": "Type library for filling positions inside Markdown documents authored in the template; the template text carries the document's headings, list markers, table headers and code fences verbatim",
+  "version": "1.0.0",
+  "instructionTypes": {
+    "markdown_text": {
+      "template": "<<Replace this placeholder with inline Markdown text using this user prompt: ([{<{description}>}]). Format requirements: Produce a single line of text valid at the current position in the surrounding line, with no block-level constructs. Inline formatting such as bold, italic, code spans and links is allowed: {allowFormatting}. Output raw, valid Markdown only - no surrounding commentary and no explanation, and do not wrap the output in code fences.>>",
+      "description": "Generates an inline text run for a position inside a line authored in the template",
+      "configSchema": {
+        "type": "object",
+        "properties": {
+          "allowFormatting": {
+            "type": "boolean",
+            "default": true
+          }
+        }
+      },
+      "examples": [
+        {
+          "config": {
+            "description": "a short tagline for the release",
+            "allowFormatting": true
+          },
+          "output": "<<Replace this placeholder with inline Markdown text using this user prompt: ([{<a short tagline for the release>}]). Format requirements: Produce a single line of text valid at the current position in the surrounding line, with no block-level constructs. Inline formatting such as bold, italic, code spans and links is allowed: true. Output raw, valid Markdown only - no surrounding commentary and no explanation, and do not wrap the output in code fences.>>"
+        }
+      ]
+    },
+    "markdown_block": {
+      "template": "<<Replace this placeholder with Markdown blocks using this user prompt: ([{<{description}>}]). Format requirements: Produce one or more complete Markdown blocks using standard notation - headings, paragraphs, bullet and numbered lists, task lists, block quotes, fenced code blocks, tables, links, images and horizontal rules - separated by blank lines and valid at this position in the enclosing document. Output raw, valid Markdown only - no surrounding commentary and no explanation, and do not wrap the output in code fences.>>",
+      "description": "Generates one or more complete Markdown blocks for a position authored in the template"
+    },
+    "markdown_list_items": {
+      "template": "<<Replace this placeholder with Markdown list items using this user prompt: ([{<{description}>}]). Format requirements: Produce list items, one per line, using {listType} markers (a hyphen and a space for bullet items, numbers in the 1. style for numbered items, - [ ] for task items), producing the number of items the prompt asks for, valid at this position in the enclosing document. Output raw, valid Markdown only - no surrounding commentary and no explanation, and do not wrap the output in code fences.>>",
+      "description": "Generates list items, one per line, for a position authored in the template",
+      "configSchema": {
+        "type": "object",
+        "properties": {
+          "listType": {
+            "type": "string",
+            "enum": [
+              "bullet",
+              "numbered",
+              "task"
+            ],
+            "default": "bullet"
+          },
+          "itemCount": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 20,
+            "description": "If specified, the exact number of items to generate"
+          }
+        }
+      },
+      "examples": [
+        {
+          "config": {
+            "description": "the headline features shipped in this release",
+            "listType": "bullet",
+            "itemCount": 3
+          },
+          "output": "<<Replace this placeholder with Markdown list items using this user prompt: ([{<the headline features shipped in this release>}]). Format requirements: Produce list items, one per line, using bullet markers (a hyphen and a space for bullet items, numbers in the 1. style for numbered items, - [ ] for task items), producing the number of items the prompt asks for, valid at this position in the enclosing document. Output raw, valid Markdown only - no surrounding commentary and no explanation, and do not wrap the output in code fences.>>"
+        }
+      ]
+    },
+    "markdown_table_rows": {
+      "template": "<<Replace this placeholder with Markdown table rows using this user prompt: ([{<{description}>}]). Format requirements: Produce table body rows, each row on its own line in the form | cell | cell |, matching the column count of the header row authored in the surrounding table, producing the number of rows the prompt asks for, without producing a header or separator row. Output raw, valid Markdown only - no surrounding commentary and no explanation, and do not wrap the output in code fences.>>",
+      "description": "Generates body rows for a table whose header row is authored in the template",
+      "configSchema": {
+        "type": "object",
+        "properties": {
+          "rows": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 50,
+            "description": "If specified, the exact number of rows to generate"
+          },
+          "columns": {
+            "type": "integer",
+            "minimum": 2,
+            "maximum": 10,
+            "description": "If specified, the number of cells per row"
+          }
+        }
+      }
+    },
+    "markdown_code": {
+      "template": "<<Replace this placeholder with code using this user prompt: ([{<{description}>}]). Format requirements: Produce the contents of the fenced code block whose fences are authored around this position, without repeating the fences, in the language stated on the opening fence where one is given. Output raw code only - no code fences, no surrounding commentary and no explanation.>>",
+      "description": "Generates the contents of a fenced code block whose fences are authored in the template",
+      "configSchema": {
+        "type": "object",
+        "properties": {
+          "language": {
+            "type": "string",
+            "description": "If specified, the programming language the code should be written in"
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/fixtures/type_libraries/markdown-types-template.json
+++ b/test/fixtures/type_libraries/markdown-types-template.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://alexanderparker.github.io/instruction-template-specification/schema/v1.0/its-base-schema-v1.json",
+  "version": "1.0.0",
+  "extends": ["./its-markdown-types-v1.json"],
+  "variables": {
+    "projectName": "example-storefront",
+    "includeInstall": true
+  },
+  "content": [
+    { "type": "text", "text": "# ${projectName} release notes\n\nSummary: " },
+    {
+      "type": "placeholder",
+      "instructionType": "markdown_text",
+      "config": {
+        "description": "a one-line summary of the ${projectName} release"
+      }
+    },
+    { "type": "text", "text": "\n\n## Features\n\n" },
+    {
+      "type": "placeholder",
+      "instructionType": "markdown_list_items",
+      "config": {
+        "description": "three headline features of ${projectName}",
+        "itemCount": 3
+      }
+    },
+    { "type": "text", "text": "\n\n| Package | Version |\n| --- | --- |\n" },
+    {
+      "type": "placeholder",
+      "instructionType": "markdown_table_rows",
+      "config": {
+        "description": "package and version rows for ${projectName}",
+        "rows": 3,
+        "columns": 2
+      }
+    },
+    {
+      "type": "conditional",
+      "condition": "includeInstall == true",
+      "content": [
+        { "type": "text", "text": "\n\n## Installation\n\n```bash\n" },
+        {
+          "type": "placeholder",
+          "instructionType": "markdown_code",
+          "config": {
+            "description": "shell commands that install ${projectName}",
+            "language": "bash"
+          }
+        },
+        { "type": "text", "text": "\n```" }
+      ]
+    }
+  ]
+}

--- a/test/integration/test_type_libraries.py
+++ b/test/integration/test_type_libraries.py
@@ -2,9 +2,9 @@
 Integration tests for the published structured-output type libraries.
 
 The libraries fill value positions inside structure authored verbatim in the
-template text. Local fixture copies of the JSON, HTML and YAML libraries are
-loaded through relative extends with local schemas enabled, so no network is
-involved.
+template text. Local fixture copies of the JSON, HTML, YAML and Markdown
+libraries are loaded through relative extends with local schemas enabled, so
+no network is involved.
 """
 
 from pathlib import Path
@@ -21,6 +21,11 @@ RAW_OUTPUT_CLAUSES = {
     "json": "Output raw, valid JSON only - no markdown code fences, no surrounding commentary, and no explanation.",
     "html": "Output raw, valid HTML only - no markdown code fences, no surrounding commentary, and no explanation.",
     "yaml": "Output raw, valid YAML only - no markdown code fences, no surrounding commentary, and no explanation.",
+    "markdown": (
+        "Output raw, valid Markdown only - no surrounding commentary and no explanation, "
+        "and do not wrap the output in code fences."
+    ),
+    "markdown_code": "Output raw code only - no code fences, no surrounding commentary and no explanation.",
 }
 
 PUBLISHED_BASE = "https://alexanderparker.github.io/instruction-template-specification/schema/v1.0"
@@ -48,7 +53,12 @@ class TestTypeLibrarySecurity:
         validator = URLValidator(config)
         allowlist = AllowlistManager(config)
 
-        for file_name in ["its-json-types-v1.json", "its-html-types-v1.json", "its-yaml-types-v1.json"]:
+        for file_name in [
+            "its-json-types-v1.json",
+            "its-html-types-v1.json",
+            "its-yaml-types-v1.json",
+            "its-markdown-types-v1.json",
+        ]:
             url = f"{PUBLISHED_BASE}/{file_name}"
             validator.validate_url(url)
             assert allowlist._is_builtin_trusted(url)
@@ -116,6 +126,33 @@ class TestHtmlTypeLibrary:
         assert "{includeClasses}" not in prompt
         assert "True" not in prompt
 
+    def test_complete_element_generator_html_list(self) -> None:
+        template = {
+            "$schema": "https://alexanderparker.github.io/instruction-template-specification/schema/v1.0/its-base-schema-v1.json",
+            "version": "1.0.0",
+            "extends": ["./its-html-types-v1.json"],
+            "content": [
+                {"type": "text", "text": "<nav>\n"},
+                {
+                    "type": "placeholder",
+                    "instructionType": "html_list",
+                    "config": {
+                        "description": "links to the main documentation sections",
+                        "listType": "unordered",
+                        "itemCount": 4,
+                    },
+                },
+                {"type": "text", "text": "\n</nav>"},
+            ],
+        }
+
+        result = local_compiler().compile(template, base_url=FIXTURES.resolve().as_uri() + "/")
+        prompt = str(result.prompt)
+
+        assert "Produce a complete unordered list element including its items" in prompt
+        assert RAW_OUTPUT_CLAUSES["html"] in prompt
+        assert "([{<links to the main documentation sections>}])" in prompt
+
 
 class TestYamlTypeLibrary:
     def test_authored_structure_verbatim_with_fills(self) -> None:
@@ -128,3 +165,35 @@ class TestYamlTypeLibrary:
         # yaml_block placeholder relies on the indentSpaces default
         assert "indented by 2 spaces" in prompt
         assert "{indentSpaces}" not in prompt
+
+
+class TestMarkdownTypeLibrary:
+    def test_authored_scaffolding_verbatim_with_fills(self) -> None:
+        prompt = compile_fixture("markdown-types-template.json")
+
+        # The document scaffolding comes from the template text, not the model
+        assert "# example-storefront release notes" in prompt
+        assert "## Features\n" in prompt
+        assert "| Package | Version |\n| --- | --- |\n" in prompt
+        assert "## Installation\n\n```bash\n" in prompt
+        assert "\n```" in prompt
+        # Fills carry the raw-output clauses and escaped descriptions
+        assert RAW_OUTPUT_CLAUSES["markdown"] in prompt
+        assert RAW_OUTPUT_CLAUSES["markdown_code"] in prompt
+        assert "([{<three headline features of example-storefront>}])" in prompt
+        assert "without producing a header or separator row" in prompt
+
+    def test_conditionals_follow_variables(self) -> None:
+        with_install = compile_fixture("markdown-types-template.json")
+        assert "## Installation" in with_install
+
+        without_install = compile_fixture("markdown-types-template.json", {"includeInstall": False})
+        assert "## Installation" not in without_install
+        assert "```bash" not in without_install
+
+    def test_defaults_render_when_config_omitted(self) -> None:
+        # The markdown_list_items placeholder omits listType; the default is bullet
+        prompt = compile_fixture("markdown-types-template.json")
+
+        assert "using bullet markers" in prompt
+        assert "{listType}" not in prompt


### PR DESCRIPTION
Integration tests for the new markdown library (5 types) and the expanded HTML library (15 types incl. complete-element generators), mirrored across all three compilers with byte-identical fixtures. README tables updated.