### PR TITLE
Read __version__ from package metadata

### DIFF
--- a/its_compiler/__init__.py
+++ b/its_compiler/__init__.py
@@ -7,9 +7,18 @@ Converts content templates with placeholders into structured AI prompts.
 Includes comprehensive security features for safe template processing.
 """
 
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _package_version
 from typing import Any, Dict
 
-__version__ = "1.0.4"
+try:
+    # Single source of truth: the installed distribution metadata, which
+    # pyproject.toml populates. Keeps this from drifting out of step with
+    # the version declared for packaging.
+    __version__ = _package_version("its-compiler")
+except PackageNotFoundError:  # pragma: no cover - uninstalled source tree
+    __version__ = "0.0.0"
+
 __author__ = "Alexander Parker"
 __email__ = "pypi@parker.im"
 


### PR DESCRIPTION
Fixes the recorded follow-up: __version__ was pinned at 1.0.4 while pyproject said 1.2.0, so get_version() and get_security_status() reported stale data. Now sourced from installed distribution metadata; verified resolving to 1.2.0. mypy, flake8 and the 122 core tests pass.