### PR TITLE
Make the security suite assert real outcomes

### DIFF
--- a/test/integration/test_error_handling_integration.py
+++ b/test/integration/test_error_handling_integration.py
@@ -188,13 +188,23 @@ class TestErrorHandlingIntegration:
         self, production_compiler: ITSCompiler, template_fetcher: TemplateFetcher
     ) -> None:
         """Test that production errors don't leak sensitive information using real malicious templates."""
-        try:
-            template = template_fetcher.fetch_template("malicious_injection.json", category="templates/security")
+        template = template_fetcher.fetch_template("malicious_injection.json", category="templates/security")
+
+        with pytest.raises(ITSValidationError, match="Template security validation failed") as exc_info:
             production_compiler.compile(template)
-        except Exception as e:
-            error_msg = str(e)
-            # Should provide generic security message without exposing attack details
-            assert "security" in error_msg.lower() or "validation" in error_msg.lower()
+
+        error_msg = str(exc_info.value)
+
+        # The message identifies the failing element without echoing the payload it rejected
+        assert "<script" not in error_msg.lower()
+        assert "alert(" not in error_msg.lower()
+        assert "javascript:" not in error_msg.lower()
+
+        # No internal paths or diagnostic detail, and no dump of the template
+        assert "/etc/passwd" not in error_msg
+        assert "internal" not in error_msg.lower()
+        assert "debug" not in error_msg.lower()
+        assert len(error_msg) < 200
 
     def test_complex_template_variable_error_recovery(
         self, compiler: ITSCompiler, template_fetcher: TemplateFetcher

--- a/test/security/test_allowlist_manager.py
+++ b/test/security/test_allowlist_manager.py
@@ -2,6 +2,7 @@
 Tests for AllowlistManager security functionality.
 """
 
+import hashlib
 import json
 import tempfile
 from datetime import datetime, timezone
@@ -209,17 +210,31 @@ class TestAllowlistManager:
         assert entry.fingerprint is not None
         assert len(entry.fingerprint) == 16  # SHA256 first 16 chars
 
-    def test_fingerprint_change_detection(self, allowlist_manager: AllowlistManager) -> None:
-        """Test detection of fingerprint changes."""
+    def test_fingerprint_change_detection(
+        self, allowlist_manager: AllowlistManager, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Test changed schema content is reported and the stored fingerprint is replaced."""
         url = "https://company.com/schema.json"
         old_content = '{"version": "1.0"}'
         new_content = '{"version": "2.0"}'
 
         allowlist_manager.add_trusted_url(url, TrustLevel.PERMANENT)
         allowlist_manager.update_fingerprint(url, old_content)
+        original_fingerprint = allowlist_manager.entries[url].fingerprint
+        capsys.readouterr()  # Discard output from the first fingerprint
 
-        # Update with different content
         allowlist_manager.update_fingerprint(url, new_content)
+
+        updated_fingerprint = allowlist_manager.entries[url].fingerprint
+        assert updated_fingerprint != original_fingerprint
+        assert updated_fingerprint == hashlib.sha256(new_content.encode("utf-8")).hexdigest()[:16]
+        assert f"Warning: Schema content changed for {url}" in capsys.readouterr().out
+
+        # Re-applying identical content is not reported as a change
+        allowlist_manager.update_fingerprint(url, new_content)
+
+        assert "Schema content changed" not in capsys.readouterr().out
+        assert allowlist_manager.entries[url].fingerprint == updated_fingerprint
 
     def test_get_stats(self, allowlist_manager: AllowlistManager) -> None:
         """Test getting allowlist statistics."""
@@ -411,8 +426,17 @@ class TestAllowlistManager:
         manager = AllowlistManager(security_config)
         assert manager.entries == {}
 
-    def test_file_permission_error_handling(self, allowlist_manager: AllowlistManager) -> None:
-        """Test handling of file permission errors."""
+    def test_file_permission_error_handling(
+        self, allowlist_manager: AllowlistManager, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Test a failed save is reported as a warning and leaves the entry usable in memory."""
+        url = "https://test.com/s.json"
+
         # Try to save to read-only location (simulated by mocking)
         with patch("builtins.open", side_effect=PermissionError("Access denied")):
-            allowlist_manager.add_trusted_url("https://test.com/s.json", TrustLevel.PERMANENT)
+            allowlist_manager.add_trusted_url(url, TrustLevel.PERMANENT)
+
+        assert "Warning: Failed to save allowlist: Access denied" in capsys.readouterr().out
+        assert allowlist_manager.entries[url].trust_level == TrustLevel.PERMANENT
+        assert allowlist_manager.is_allowed(url)
+        assert not allowlist_manager.allowlist_path.exists()

--- a/test/security/test_expression_sanitiser.py
+++ b/test/security/test_expression_sanitiser.py
@@ -2,6 +2,7 @@
 Tests for ExpressionSanitiser AST injection prevention and expression validation.
 """
 
+import re
 from typing import Any, Dict
 
 import pytest
@@ -46,6 +47,50 @@ def test_sanitiser_with_small_limits() -> ExpressionSanitiser:
     return ExpressionSanitiser(config)
 
 
+@pytest.fixture
+def dos_sanitiser() -> ExpressionSanitiser:
+    """Create a sanitiser with a generous length limit so per-vector limits are the ones that trip."""
+    config = SecurityConfig.for_development()
+    config.processing.max_expression_length = 10000
+    config.processing.max_expression_depth = 8
+    config.processing.max_variable_references = 100
+    return ExpressionSanitiser(config)
+
+
+def build_nested_expression(levels: int) -> str:
+    """Build an expression nested to the requested number of levels."""
+    expression = "test"
+    for _ in range(levels):
+        expression = f"({expression} and test)"
+    return expression
+
+
+# Denial of service vectors, each paired with the limit that is expected to reject it
+DOS_VECTORS = [
+    pytest.param(
+        build_nested_expression(50),
+        {"test": True},
+        "nesting_too_deep",
+        "Expression nesting too deep",
+        id="cpu_exhaustion_via_deep_nesting",
+    ),
+    pytest.param(
+        "test in [" + ", ".join(str(i) for i in range(1000)) + "]",
+        {"test": True},
+        "literal_too_large",
+        "Literal too large: 1000 elements",
+        id="memory_exhaustion_via_large_literal",
+    ),
+    pytest.param(
+        " and ".join(f"var{i} == True" for i in range(200)),
+        {f"var{i}": True for i in range(200)},
+        "too_many_variables",
+        "Too many variable references: 200",
+        id="variable_reference_explosion",
+    ),
+]
+
+
 class TestExpressionSanitiser:
     """Test ExpressionSanitiser security functionality."""
 
@@ -69,28 +114,24 @@ class TestExpressionSanitiser:
             result = expression_sanitiser.sanitise_expression(expr, variables)
             assert result == expr  # Should return unchanged
 
-    def test_valid_complex_expressions(self, expression_sanitiser: ExpressionSanitiser) -> None:
-        """Test valid complex expressions pass validation."""
+    @pytest.mark.parametrize(
+        "expression",
+        [
+            "settings.debug == True and settings.level > 1",
+            'status == "active" or status == "pending"',
+            "items[0] == 1 and items[2] == 3",
+            'settings.level >= 2 and status != "inactive"',
+        ],
+    )
+    def test_valid_complex_expressions(self, expression_sanitiser: ExpressionSanitiser, expression: str) -> None:
+        """Test valid complex expressions pass validation and are returned unchanged."""
         variables = {
             "settings": {"debug": True, "level": 2},
             "items": [1, 2, 3],
             "status": "active",
         }
 
-        complex_expressions = [
-            "settings.debug == True and settings.level > 1",
-            'status == "active" or status == "pending"',
-            "items[0] == 1 and items[2] == 3",
-            'settings.level >= 2 and status != "inactive"',
-        ]
-
-        # Note: some of these might fail due to security restrictions
-        for expr in complex_expressions:
-            try:
-                expression_sanitiser.sanitise_expression(expr, variables)
-            except ExpressionSecurityError:
-                # Expected for some expressions with forbidden constructs
-                pass
+        assert expression_sanitiser.sanitise_expression(expression, variables) == expression
 
     def test_expression_too_long(self, expression_sanitiser: ExpressionSanitiser) -> None:
         """Test expressions that exceed length limits are rejected."""
@@ -274,14 +315,37 @@ class TestExpressionSanitiser:
         assert "Variable name too long" in str(exc_info.value)
         assert exc_info.value.reason == "variable_name_too_long"
 
-    def test_invalid_variable_characters(self, expression_sanitiser: ExpressionSanitiser) -> None:
-        """Test variable names with invalid characters are rejected."""
-        # This would be caught at the parsing stage, but test the validation
-        variables = {"test": True}
+    @pytest.mark.parametrize(
+        "expression, message, reason",
+        [
+            pytest.param(
+                "café == True",
+                "Invalid characters in variable name: café",
+                "invalid_variable_chars",
+                id="non_ascii_identifier",
+            ),
+            pytest.param(
+                "test-invalid == True",
+                "Forbidden AST node type: BinOp",
+                "forbidden_node_type",
+                id="hyphen_parsed_as_subtraction",
+            ),
+        ],
+    )
+    def test_invalid_variable_characters(
+        self,
+        expression_sanitiser: ExpressionSanitiser,
+        expression: str,
+        message: str,
+        reason: str,
+    ) -> None:
+        """Test variable names outside the allowed character set are rejected."""
+        variables = {"test": True, "café": True}
 
-        # Invalid variable syntax should cause syntax error
-        with pytest.raises(ExpressionSecurityError):
-            expression_sanitiser.sanitise_expression("test-invalid == True", variables)
+        with pytest.raises(ExpressionSecurityError, match=re.escape(message)) as exc_info:
+            expression_sanitiser.sanitise_expression(expression, variables)
+
+        assert exc_info.value.reason == reason
 
     def test_attribute_access_validation(self, expression_sanitiser: ExpressionSanitiser) -> None:
         """Test object attribute access validation."""
@@ -369,17 +433,20 @@ class TestExpressionSanitiser:
         # Could be caught by variable count or expression length limit
         assert "Too many variable references" in error_msg or "Expression too long" in error_msg
 
-    def test_undefined_variable_logging(self, expression_sanitiser: ExpressionSanitiser) -> None:
-        """Test undefined variable reference logging."""
+    def test_undefined_variable_logging(
+        self, expression_sanitiser: ExpressionSanitiser, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Test undefined variable references are logged as warnings rather than rejected."""
         variables = {"defined": True}
-        # The implementation logs undefined variables but doesn't necessarily raise an error
-        # This behavior is acceptable - undefined variables are logged as warnings
-        try:
-            expression_sanitiser.sanitise_expression("undefined == True", variables)
-            # If it succeeds, that's fine - undefined variables are just logged
-        except ExpressionSecurityError:
-            # If it fails for other security reasons, that's also acceptable
-            pass
+
+        result = expression_sanitiser.sanitise_expression("undefined == True", variables)
+
+        assert result == "undefined == True"
+        assert "Warning: undefined variable 'undefined' in expression" in capsys.readouterr().out
+
+        # A defined variable produces no warning
+        assert expression_sanitiser.sanitise_expression("defined == True", variables) == "defined == True"
+        assert "undefined variable" not in capsys.readouterr().out
 
     def test_get_expression_complexity(self, expression_sanitiser: ExpressionSanitiser) -> None:
         """Test expression complexity analysis."""
@@ -447,26 +514,44 @@ class TestExpressionSanitiser:
         for pattern in expected_patterns:
             assert pattern in patterns
 
-    def test_production_security_limits(self, production_sanitiser: ExpressionSanitiser) -> None:
-        """Test stricter limits in production mode."""
+    def test_production_security_limits(
+        self,
+        expression_sanitiser: ExpressionSanitiser,
+        production_sanitiser: ExpressionSanitiser,
+    ) -> None:
+        """Test the expression length limit is stricter in production than in development."""
         variables = {"test": True}
 
-        # Expression that passes in dev but fails in production
-        long_expr = " and ".join(["test == True"] * 30)  # Exceeds production limits
+        # 420 characters: inside the development limit of 500, over the production limit of 200
+        long_expr = " and ".join(["test == True"] * 25)
+        assert len(long_expr) == 420
 
-        with pytest.raises(ExpressionSecurityError):
+        assert expression_sanitiser.sanitise_expression(long_expr, variables) == long_expr
+
+        with pytest.raises(ExpressionSecurityError, match="Expression too long: 420 characters") as exc_info:
             production_sanitiser.sanitise_expression(long_expr, variables)
+
+        assert exc_info.value.reason == "expression_too_long"
 
     def test_security_context_in_errors(self, expression_sanitiser: ExpressionSanitiser) -> None:
         """Test security context is preserved in errors."""
         variables = {"test": True}
+        expression = "exec('malicious')"
 
-        try:
-            expression_sanitiser.sanitise_expression("exec('malicious')", variables)
-        except ExpressionSecurityError as e:
-            assert e.expression is not None
-            assert e.reason is not None
-            assert "malicious" in e.expression or len(e.expression) == 100  # Truncated
+        with pytest.raises(ExpressionSecurityError, match="Dangerous pattern detected in expression") as exc_info:
+            expression_sanitiser.sanitise_expression(expression, variables)
+
+        assert exc_info.value.expression == expression
+        assert exc_info.value.reason == "dangerous_pattern"
+
+        # The expression carried on the error is truncated to 100 characters
+        long_expression = "exec('" + "a" * 200 + "')"
+
+        with pytest.raises(ExpressionSecurityError) as long_exc_info:
+            expression_sanitiser.sanitise_expression(long_expression, variables)
+
+        assert long_exc_info.value.expression == long_expression[:100]
+        assert long_exc_info.value.reason == "dangerous_pattern"
 
     def test_comprehensive_attack_simulation(self, expression_sanitiser: ExpressionSanitiser) -> None:
         """Test comprehensive attack simulation covering all security vectors."""
@@ -525,25 +610,17 @@ class TestExpressionSanitiser:
                 # If it fails due to security rules, that's also acceptable
                 pass
 
-    def test_performance_dos_prevention(self, production_sanitiser: ExpressionSanitiser) -> None:
-        """Test prevention of performance-based denial of service attacks."""
-        variables = {"test": True}
+    @pytest.mark.parametrize("expression, variables, reason, message", DOS_VECTORS)
+    def test_performance_dos_prevention(
+        self,
+        dos_sanitiser: ExpressionSanitiser,
+        expression: str,
+        variables: Dict[str, Any],
+        reason: str,
+        message: str,
+    ) -> None:
+        """Test each denial of service vector is rejected by its own limit, not just by overall length."""
+        with pytest.raises(ExpressionSecurityError, match=re.escape(message)) as exc_info:
+            dos_sanitiser.sanitise_expression(expression, variables)
 
-        # CPU exhaustion through deep nesting
-        deep_expr = "test"
-        for _ in range(50):  # Very deep nesting
-            deep_expr = f"({deep_expr} and test)"
-
-        with pytest.raises(ExpressionSecurityError):
-            production_sanitiser.sanitise_expression(deep_expr, variables)
-
-        # Memory exhaustion through large literals
-        large_literal = "[" + ", ".join([str(i) for i in range(1000)]) + "]"
-        with pytest.raises(ExpressionSecurityError):
-            production_sanitiser.sanitise_expression(f"test in {large_literal}", variables)
-
-        # Variable reference explosion
-        many_vars = {f"var{i}": True for i in range(200)}
-        var_expr = " and ".join([f"var{i} == True" for i in range(200)])
-        with pytest.raises(ExpressionSecurityError):
-            production_sanitiser.sanitise_expression(var_expr, many_vars)
+        assert exc_info.value.reason == reason

--- a/test/security/test_security_integration.py
+++ b/test/security/test_security_integration.py
@@ -13,7 +13,7 @@ import pytest
 from its_compiler import ITSCompiler
 from its_compiler.core.exceptions import ITSCompilationError, ITSConditionalError, ITSSecurityError, ITSValidationError
 from its_compiler.core.models import ITSConfig
-from its_compiler.security import SecurityConfig
+from its_compiler.security import SecurityConfig, URLSecurityError
 
 
 @pytest.fixture
@@ -176,20 +176,28 @@ class TestSecurityIntegration:
             assert len(result.prompt) > 0
 
     def test_production_security_with_real_templates(self, production_compiler: ITSCompiler, fetcher: Any) -> None:
-        """Test production security settings with real templates."""
-        # Simple template should work in production
+        """Test production security settings still compile legitimate templates in full."""
+        # Simple template compiles unchanged
         simple_template = fetcher.fetch_template("01-text-only.json")
-        result = production_compiler.compile(simple_template)
-        assert result.prompt is not None
+        simple_result = production_compiler.compile(simple_template)
+        assert "This is a simple template with no placeholders" in simple_result.prompt
 
-        # Complex template might be more restricted in production
+        # Every conditional branch of the complex template is still evaluated in production
         complex_template = fetcher.fetch_template("10-comprehensive-conditionals.json")
-        try:
-            result = production_compiler.compile(complex_template)
-            assert result.prompt is not None
-        except (ITSValidationError, ITSSecurityError):
-            # Production might be more restrictive, which is acceptable
-            pass
+        complex_result = production_compiler.compile(complex_template)
+
+        assert "# Conditional Operator Tests" in complex_result.prompt
+        for operator_case in [
+            "[OK] Unary NOT operator works",
+            "[OK] AND operator with comparisons works",
+            "[OK] IN operator with list works",
+            "[OK] NOT IN operator works",
+            "[OK] Parentheses and complex logic work",
+        ]:
+            assert operator_case in complex_result.prompt
+
+        # No unresolved variable references remain
+        assert "${" not in complex_result.prompt
 
     def test_security_with_variable_substitution(self, compiler: ITSCompiler, fetcher: Any) -> None:
         """Test security validation works with variable substitution."""
@@ -272,28 +280,19 @@ class TestSecurityIntegration:
         assert status["features"]["expression_sanitisation"] is True
 
     def test_file_path_traversal_prevention(self, compiler: ITSCompiler, temp_dir: Path) -> None:
-        """Test file path traversal attacks are prevented."""
-        # Create malicious template file path
+        """Test path traversal is rejected by URL validation before any request is made."""
+        traversal_schema_url = "https://alexanderparker.github.io/../../etc/passwd"
+
+        with pytest.raises(URLSecurityError, match="Path traversal detected") as url_exc_info:
+            compiler.schema_loader.load_schema(traversal_schema_url)
+
+        assert url_exc_info.value.reason == "path_traversal"
+
+        # A traversal template path is refused with a compilation error rather than an unhandled OSError
         malicious_path = temp_dir / "subdir" / ".." / ".." / "etc" / "passwd"
 
-        # Should block or sanitize path traversal
-        with pytest.raises((ITSValidationError, ITSCompilationError, FileNotFoundError)):
+        with pytest.raises(ITSCompilationError, match="Template file not found"):
             compiler.compile_file(str(malicious_path))
-
-    def test_error_information_disclosure(self, production_compiler: ITSCompiler, fetcher: Any) -> None:
-        """Test error messages don't disclose sensitive information."""
-        template = fetcher.fetch_template("malicious_injection.json", category="templates/security")
-
-        try:
-            production_compiler.compile(template)
-        except Exception as e:
-            error_msg = str(e)
-            # Should not expose internal paths or sensitive details
-            assert "/etc/passwd" not in error_msg
-            assert "internal" not in error_msg.lower()
-            assert "debug" not in error_msg.lower()
-            # Should not expose full template content
-            assert len(error_msg) < 1000  # Reasonable error message length
 
     def test_environment_variable_configuration_coverage(self) -> None:
         """Test environment variable configuration paths to cover config.py missing lines."""

--- a/test/security/test_url_validator.py
+++ b/test/security/test_url_validator.py
@@ -3,6 +3,7 @@ Tests for URLValidator SSRF protection and URL security validation.
 """
 
 import socket
+from typing import Any, Optional, Tuple
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -361,13 +362,19 @@ class TestURLValidator:
         result = url_validator.remove_allowed_domain("example.invalid")
         assert result is False
 
-    def test_ssrf_attempt_logging(self, url_validator: URLValidator) -> None:
-        """Test SSRF attempt logging."""
+    def test_ssrf_attempt_logging(self, url_validator: URLValidator, capsys: pytest.CaptureFixture[str]) -> None:
+        """Test SSRF attempts are blocked by SSRF protection and logged."""
         url_validator.config.network.block_localhost = True
+        # Disable the domain allowlist so the SSRF layer is the one that rejects the URL
+        url_validator.config.network.enforce_domain_allowlist = False
         url = "https://127.0.0.1/schema.json"
 
-        with pytest.raises(URLSecurityError):
+        with pytest.raises(URLSecurityError, match="Localhost access blocked: 127.0.0.1") as exc_info:
             url_validator.validate_url(url)
+
+        assert exc_info.value.reason == "ssrf_blocked"
+        assert exc_info.value.url == url
+        assert "SSRF protection: Localhost access blocked: 127.0.0.1" in capsys.readouterr().out
 
     @patch("socket.getaddrinfo")
     def test_invalid_ip_address_format(self, mock_getaddrinfo: MagicMock, url_validator: URLValidator) -> None:
@@ -395,45 +402,56 @@ class TestURLValidator:
         # Should have skipped the invalid range
         assert len(validator._blocked_networks) == len(security_config.network.blocked_ip_ranges) - 1
 
-    def test_edge_case_urls(self, url_validator: URLValidator) -> None:
-        """Test various edge case URLs."""
+    @pytest.mark.parametrize(
+        "url, resolved_address, expected_reason",
+        [
+            pytest.param(
+                "https://127.0.0.1:8080/path",
+                ("127.0.0.1", 8080),
+                "ssrf_blocked",
+                id="ipv4_loopback_with_port",
+            ),
+            pytest.param(
+                "https://[::1]:8080/path",
+                ("::1", 8080, 0, 0),
+                "ssrf_blocked",
+                id="ipv6_loopback_with_port",
+            ),
+            pytest.param(
+                "https://example.com/path?query=value",
+                ("93.184.216.34", 80),
+                None,
+                id="query_string",
+            ),
+            pytest.param(
+                "https://example.com/path#fragment",
+                ("93.184.216.34", 80),
+                None,
+                id="fragment",
+            ),
+        ],
+    )
+    def test_edge_case_urls(
+        self,
+        url_validator: URLValidator,
+        url: str,
+        resolved_address: Tuple[Any, ...],
+        expected_reason: Optional[str],
+    ) -> None:
+        """Test ports, IPv6 literals, query strings and fragments do not change the security verdict."""
         url_validator.config.network.enforce_domain_allowlist = False
+        # Loopback stays blocked through the blocked IP ranges even with the localhost check disabled
         url_validator.config.network.block_localhost = False
 
-        edge_cases = [
-            ("https://127.0.0.1:8080/path", "Should handle ports"),
-            ("https://[::1]:8080/path", "Should handle IPv6 with ports"),
-            ("https://example.com/path?query=value", "Should handle query parameters"),
-            ("https://example.com/path#fragment", "Should handle fragments"),
-        ]
+        family = socket.AF_INET6 if len(resolved_address) == 4 else socket.AF_INET
 
-        for url, _ in edge_cases:
-            with patch("socket.getaddrinfo") as mock_dns:
-                if "127.0.0.1" in url:
-                    mock_dns.return_value = [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("127.0.0.1", 8080))]
-                elif "::1" in url:
-                    mock_dns.return_value = [
-                        (
-                            socket.AF_INET6,
-                            socket.SOCK_STREAM,
-                            6,
-                            "",
-                            ("::1", 8080, 0, 0),
-                        )
-                    ]
-                else:
-                    mock_dns.return_value = [
-                        (
-                            socket.AF_INET,
-                            socket.SOCK_STREAM,
-                            6,
-                            "",
-                            ("93.184.216.34", 80),
-                        )
-                    ]
+        with patch("socket.getaddrinfo") as mock_dns:
+            mock_dns.return_value = [(family, socket.SOCK_STREAM, 6, "", resolved_address)]
 
-                try:
+            if expected_reason is None:
+                url_validator.validate_url(url)
+            else:
+                with pytest.raises(URLSecurityError) as exc_info:
                     url_validator.validate_url(url)
-                except URLSecurityError:
-                    # Some edge cases might still fail due to security rules, that's OK
-                    pass
+
+                assert exc_info.value.reason == expected_reason


### PR DESCRIPTION
Fixes the recorded audit follow-up. Tests that asserted nothing, asserted inside except blocks, or used bare pytest.raises now assert the specific behaviour, checked against the implementation. Notable findings: loopback stays blocked when block_localhost is False (blocked_ip_ranges catches it), the SSRF test was being stopped by the domain allowlist instead, and compile_file has no traversal defence so that assertion moved to URLValidator. One duplicate deleted. 338 passed, linters and mypy clean.