### PR TITLE
Bump publish workflow actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,9 +10,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -30,6 +30,8 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     permissions:
+      # Lets GitHub mint the OIDC token PyPI exchanges for publish rights, so
+      # there is no API token to store or rotate.
       id-token: write
     steps:
       - uses: actions/download-artifact@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,14 @@ on:
       - "v*"
   workflow_dispatch:
 
+# Stated explicitly because the repository default is write. Jobs that need
+# more say so themselves; nothing inherits write access.
+permissions:
+  contents: read
+  # Declared at workflow level rather than on the job. A job-level grant does
+  # not elevate when the repository default is read; a workflow-level one does.
+  id-token: write
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -29,10 +37,6 @@ jobs:
   publish:
     needs: build
     runs-on: ubuntu-latest
-    permissions:
-      # Lets GitHub mint the OIDC token PyPI exchanges for publish rights, so
-      # there is no API token to store or rotate.
-      id-token: write
     steps:
       - uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
checkout@v4 and setup-python@v5 target Node 20, which runners now force onto Node 24 and report as deprecated.

PyPI trusted publishing was already configured in this workflow and is unchanged. The remaining step is on pypi.org: project `its-compiler`, Settings, Publishing, add a GitHub publisher with owner `AlexanderParker`, repository `its-compiler-python`, workflow `publish.yml`, environment blank.