### PR TITLE
Render scalars identically across all three compilers

### DIFF
--- a/its_compiler/core/variable_processor.py
+++ b/its_compiler/core/variable_processor.py
@@ -302,7 +302,7 @@ class VariableProcessor:
 
         elif isinstance(value, list):
             # Convert arrays to comma-separated string
-            return ", ".join(str(item) for item in value)
+            return ", ".join(self.render_scalar(item) for item in value)
 
         elif isinstance(value, dict):
             # Convert objects to safe string representation
@@ -310,7 +310,7 @@ class VariableProcessor:
 
         else:
             # Convert other types to string with length limit
-            str_value = str(value)
+            str_value = self.render_scalar(value)
             max_text_length = self.security_config.processing.max_text_length
             if len(str_value) > max_text_length:
                 str_value = str_value[:max_text_length] + "... [TRUNCATED]"
@@ -489,7 +489,7 @@ class VariableProcessor:
                 items.append(item[arg])
 
         if name == "concat":
-            return ", ".join(self._concat_text(item) for item in items)
+            return ", ".join(self.render_scalar(item) for item in items)
 
         numbers: List[float] = []
         for item in items:
@@ -510,12 +510,47 @@ class VariableProcessor:
         return self._normalise_number(max(numbers))
 
     @staticmethod
-    def _concat_text(item: Any) -> str:
-        if item is None:
+    def render_scalar(value: Any) -> str:
+        """
+        Render a scalar exactly as the JavaScript and .NET compilers do.
+
+        Every implementation used its own language's stringification, which
+        agreed on common values and diverged at the edges: Python produced
+        True, None and 1.0 where the others produced true, null and 1. This is
+        the single definition all three now share.
+        """
+        if value is None:
             return "null"
-        if isinstance(item, bool):
-            return "true" if item else "false"
-        return str(item)
+        if isinstance(value, bool):
+            return "true" if value else "false"
+        if isinstance(value, (int, float)):
+            return VariableProcessor.render_number(value)
+        return str(value)
+
+    @staticmethod
+    def render_number(value: Any) -> str:
+        """
+        Render a number in the canonical form.
+
+        Whole values carry no decimal part, and exponent notation uses a
+        lowercase e with no plus sign and no leading zeros in the exponent, so
+        1e-07 and 1E-07 both become 1e-7.
+        """
+        if isinstance(value, bool):
+            return "true" if value else "false"
+
+        if isinstance(value, float) and value.is_integer() and abs(value) < 1e16:
+            value = int(value)
+
+        text = repr(value) if isinstance(value, float) else str(value)
+
+        if "e" in text or "E" in text:
+            mantissa, _, exponent = text.replace("E", "e").partition("e")
+            sign = "-" if exponent.startswith("-") else ""
+            digits = exponent.lstrip("+-").lstrip("0") or "0"
+            text = f"{mantissa}e{sign}{digits}"
+
+        return text
 
     @staticmethod
     def _normalise_number(value: float) -> Any:

--- a/test/fixtures/type-rendering.json
+++ b/test/fixtures/type-rendering.json
@@ -1,0 +1,137 @@
+{
+  "version": "1.0.0",
+  "variables": {
+    "yes": true,
+    "no": false,
+    "nothing": null,
+    "wholeFloat": 1.0,
+    "fraction": 0.5,
+    "repeating": 0.1,
+    "negative": -42,
+    "negativeFraction": -0.25,
+    "zero": 0,
+    "big": 1000000000000000,
+    "small": 1e-07,
+    "precise": 1.005,
+    "words": [
+      "alpha",
+      "beta"
+    ],
+    "mixed": [
+      1,
+      true,
+      null,
+      "x",
+      2.5
+    ],
+    "numbers": [
+      1,
+      2,
+      3,
+      4
+    ],
+    "thirds": [
+      1,
+      1,
+      1
+    ],
+    "money": [
+      0.1,
+      0.2
+    ],
+    "unicode": "café — naïve ☂",
+    "quoted": "she said \"hi\"",
+    "rows": [
+      {
+        "label": "a",
+        "value": 1.5,
+        "flag": true
+      },
+      {
+        "label": "b",
+        "value": 2.5,
+        "flag": false
+      }
+    ]
+  },
+  "content": [
+    {
+      "type": "text",
+      "text": "bool-true=${yes}\nbool-false=${no}\nnull=${nothing}\n"
+    },
+    {
+      "type": "text",
+      "text": "whole-float=${wholeFloat}\nfraction=${fraction}\nrepeating=${repeating}\n"
+    },
+    {
+      "type": "text",
+      "text": "negative=${negative}\nnegative-fraction=${negativeFraction}\nzero=${zero}\n"
+    },
+    {
+      "type": "text",
+      "text": "big=${big}\nsmall=${small}\nprecise=${precise}\n"
+    },
+    {
+      "type": "text",
+      "text": "array-strings=${words}\narray-mixed=${mixed}\n"
+    },
+    {
+      "type": "text",
+      "text": "unicode=${unicode}\nquoted=${quoted}\n"
+    },
+    {
+      "type": "text",
+      "text": "len-array=${words.length}\nlen-string=${unicode.length}\n"
+    },
+    {
+      "type": "text",
+      "text": "sum-int=${numbers.sum()}\navg-int=${numbers.avg()}\nmin=${numbers.min()}\nmax=${numbers.max()}\n"
+    },
+    {
+      "type": "text",
+      "text": "sum-float=${money.sum()}\navg-thirds=${thirds.avg()}\navg-money=${money.avg()}\n"
+    },
+    {
+      "type": "text",
+      "text": "concat-scalars=${words.concat()}\nconcat-mixed=${mixed.concat()}\n"
+    },
+    {
+      "type": "text",
+      "text": "concat-prop=${rows.concat(label)}\nsum-prop=${rows.sum(value)}\nconcat-flags=${rows.concat(flag)}\n"
+    },
+    {
+      "type": "text",
+      "text": "top2=${numbers.top(2)}\nindex-neg=${words[-1]}\nindex-0=${words[0]}\n"
+    },
+    {
+      "type": "conditional",
+      "condition": "yes and not no",
+      "content": [
+        {
+          "type": "text",
+          "text": "cond-bool=taken\n"
+        }
+      ]
+    },
+    {
+      "type": "conditional",
+      "condition": "wholeFloat == 1",
+      "content": [
+        {
+          "type": "text",
+          "text": "cond-float-eq-int=taken\n"
+        }
+      ]
+    },
+    {
+      "type": "conditional",
+      "condition": "\"alpha\" in words and negative < 0",
+      "content": [
+        {
+          "type": "text",
+          "text": "cond-in-and-negative=taken\n"
+        }
+      ]
+    }
+  ]
+}

--- a/test/test_type_rendering_parity.py
+++ b/test/test_type_rendering_parity.py
@@ -1,0 +1,98 @@
+"""
+Cross-compiler type-rendering parity.
+
+The golden-prompt comparison checks one whole template byte-for-byte, which is
+a strong check but a narrow one: that template contains no ``false``, no
+``null`` and no negative numbers. A boolean rendering divergence lived in the
+compilers for months and reached the published example outputs without failing
+anything.
+
+This fixture is broad instead. Every line is ``name=${expression}``, so a
+divergence names itself. The same fixture and the same expectations are
+asserted by its-compiler-js and Its.Compiler (.NET), which is what makes it a
+parity test rather than a snapshot.
+
+If a value here changes, the three compilers have diverged. Fix the
+divergence; do not edit the expectation to match one implementation.
+"""
+
+import re
+from pathlib import Path
+from typing import Dict
+
+import pytest
+
+from its_compiler import ITSCompiler
+
+FIXTURE = Path(__file__).parent / "fixtures" / "type-rendering.json"
+
+# The canonical rendering every implementation must produce.
+EXPECTED: Dict[str, str] = {
+    # Booleans and null are lowercase words, never a language's own spelling.
+    # This module used to emit True, False and None here.
+    "bool-true": "true",
+    "bool-false": "false",
+    "null": "null",
+    # Whole values carry no decimal part, however they were written.
+    "whole-float": "1",
+    "fraction": "0.5",
+    "repeating": "0.1",
+    "negative": "-42",
+    "negative-fraction": "-0.25",
+    "zero": "0",
+    "big": "1000000000000000",
+    # Exponents: lowercase e, no plus, no leading zeros. This module used to
+    # emit 1e-07 and .NET emitted 1E-07.
+    "small": "1e-7",
+    "precise": "1.005",
+    # Arrays join with ", " after each element is rendered by the same rules.
+    "array-strings": "alpha, beta",
+    "array-mixed": "1, true, null, x, 2.5",
+    "unicode": "café — naïve ☂",
+    "quoted": 'she said "hi"',
+    "len-array": "2",
+    "len-string": "14",
+    # Float arithmetic is IEEE 754 everywhere, so the artefacts must match too.
+    "sum-int": "10",
+    "avg-int": "2.5",
+    "min": "1",
+    "max": "4",
+    "sum-float": "0.30000000000000004",
+    "avg-thirds": "1",
+    "avg-money": "0.15000000000000002",
+    "concat-scalars": "alpha, beta",
+    "concat-mixed": "1, true, null, x, 2.5",
+    "concat-prop": "a, b",
+    "sum-prop": "4",
+    "concat-flags": "true, false",
+    "top2": "1, 2",
+    "index-neg": "beta",
+    "index-0": "alpha",
+    "cond-bool": "taken",
+    "cond-float-eq-int": "taken",
+    "cond-in-and-negative": "taken",
+}
+
+LINE = re.compile(r"^([a-z0-9-]+)=(.*)$")
+
+
+@pytest.fixture(scope="module")
+def rendered() -> Dict[str, str]:
+    # The fixture extends nothing and has no placeholders, so this needs no
+    # network and no schema files.
+    result = ITSCompiler().compile_file(str(FIXTURE))
+    values: Dict[str, str] = {}
+    for line in result.prompt.splitlines():
+        match = LINE.match(line)
+        if match:
+            values[match.group(1)] = match.group(2)
+    return values
+
+
+def test_every_value_is_rendered(rendered: Dict[str, str]) -> None:
+    assert sorted(rendered) == sorted(EXPECTED)
+
+
+@pytest.mark.parametrize("key,expected", sorted(EXPECTED.items()))
+def test_value_matches_the_other_compilers(rendered: Dict[str, str], key: str, expected: str) -> None:
+    assert rendered[key] == expected


### PR DESCRIPTION
Compiled output was **not** free of language-specific quirks. Six of thirty-six rendered values differed across the three compilers.

| Value | Python | JavaScript | .NET |
| --- | --- | --- | --- |
| `true` | `True` | `true` | `true` |
| `false` | `False` | `false` | `false` |
| `null` | `None` | `null` | *(empty string)* |
| `1.0` | `1.0` | `1` | `1.0` |
| `1e-7` | `1e-07` | `1e-7` | `1e-07` |
| mixed array | `1, True, None, x, 2.5` | `1, true, null, x, 2.5` | `1, true, , x, 2.5` |

The .NET null case was the worst: an empty string loses the difference between a null and a genuinely empty value.

## Why it survived

Collection functions were already correct in all three. They were routed through a shared helper when the boolean divergence was first found — and direct `${variable}` substitution was not. **The earlier fix was partial and nothing caught the rest.**

The golden-prompt comparison is byte-for-byte, which is strong, but it covers **one** template containing no `false`, no `null` and no negative numbers. The `True`/`true` defect that reached the published example outputs was in the HTML library, outside that template entirely.

## The canonical rules

Chosen to match what JavaScript already produced, which minimises churn:

1. `true` / `false` lowercase.
2. `null` for null.
3. Whole values carry no decimal part.
4. Exponents use a lowercase `e`, no plus, no leading zeros: `1e-7`.
5. Arrays join with `, ` after applying 1 to 4 to each element.

Every path now goes through one definition per compiler, including the collection functions, which had their own near-copies.

## The durable part

A shared fixture, `type-rendering.json`, and the same thirty-six expectations asserted in all three suites. Every line is `name=${expression}`, so a divergence names itself rather than showing up as a byte offset. It extends nothing and has no placeholders, so it needs no network and no schema files.

The .NET suite additionally compiles it under `de-DE` and requires byte-identical output, ruling out the comma-decimal-separator quirk.

## Verification

All three compilers now produce **identical output for all thirty-six values**, including .NET under a comma-decimal locale. Full suites: Python 375, JS 129, .NET 139.

Regenerating the example templates produced **zero** output changes — those templates never substitute a bare boolean, null or whole float, which is precisely why this hid for so long.