### PR TITLE
Point at the published NuGet package under its new name

### DIFF
--- a/README.md
+++ b/README.md
@@ -485,7 +485,7 @@ pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://
 - [Template studio demo](https://alexanderparker.github.io/its-template-studio/) - build and compile templates in the browser ([source](https://github.com/AlexanderParker/its-template-studio))
 - [its-template-editor](https://github.com/AlexanderParker/its-wysiwyg-common) - the WYSIWYG React editor component behind the studio
 - [its-compiler-js](https://github.com/AlexanderParker/its-compiler-js) - JavaScript/TypeScript reference compiler ([npm](https://www.npmjs.com/package/its-compiler-js))
-- [its-compiler-dotnet](https://github.com/AlexanderParker/its-compiler-dotnet) - .NET compiler with ASP.NET service and Azure Functions samples (NuGet publication pending)
+- [its-compiler-dotnet](https://github.com/AlexanderParker/its-compiler-dotnet) - .NET compiler with ASP.NET service and Azure Functions samples ([NuGet](https://www.nuget.org/packages/InstructionTemplateSpecification.Compiler))
 - [its-compiler-cli](https://github.com/AlexanderParker/its-compiler-cli-python) - command-line interface for the Python compiler ([PyPI](https://pypi.org/project/its-compiler-cli/))
 - [its-example-templates](https://github.com/AlexanderParker/its-example-templates) - example and test templates exercising the published schemas
 


### PR DESCRIPTION
The .NET package was renamed to `InstructionTemplateSpecification.Compiler` — the `Its.` prefix is reserved on NuGet by another author, so `Its.Compiler` could never have been published under that ID — and it is now live at 0.1.0.

Both the old package name and the "NuGet publication pending" note were wrong here.